### PR TITLE
文章に句読点を追加

### DIFF
--- a/app/views/pages/welcome.html.slim
+++ b/app/views/pages/welcome.html.slim
@@ -4,7 +4,7 @@
   p.text-slate-700.text-center.text-2xl.pt-10
     | フィヨルドブートキャンプのチーム開発プラクティスで
     br
-    | あなたが関わった Issue や PullRequest を自動で取得して一覧表示できるサービスです
+    | あなたが関わった Issue や PullRequest を自動で取得して一覧表示できるサービスです。
 
   .flex.justify-around.py-16
     .flex.flex-col.justify-center.w-52.items-center.p-4.bg-gray-50.border.border-gray-300.rounded-lg.shadow
@@ -33,7 +33,7 @@
         = 'Wikiページ'
 
   .text-slate-700.text-center.pt-5.text-xl.mb-10
-    | 初めて利用する方はGitHubアカウントを連携してください
+    | 初めて利用する方はGitHubアカウントを連携してください。
 
   .flex.justify-center.items-stretch.mb-10.h-12
     = button_tag class: 'text-center py-2 px-5 font-semibold text-gray-200 focus:outline-none bg-slate-600 rounded-lg border border-gray-200 hover:bg-slate-500 hover:text-gray-200 focus:z-10 focus:ring-4 focus:ring-gray-100' do


### PR DESCRIPTION
## Issue

- #65 


## 概要

見出し以外の文章に句読点を追加した。



## 変更前

<img src="https://github.com/user-attachments/assets/e2c5df71-32d6-4a46-84bf-0136eb128192" width="650" />



## 変更後

<img src="https://github.com/user-attachments/assets/2ef8048b-347b-449f-aa39-56607a20304b" width="650" />

