### PR TITLE
GitHub API から ユーザーが担当した Issue を取得する機能＆一覧表示を作成

### DIFF
--- a/app/controllers/users/issues_controller.rb
+++ b/app/controllers/users/issues_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class User::IssuesController < ApplicationController
+class Users::IssuesController < ApplicationController
   def index
     @repository = Repository.find_by(name: ENV['REPOSITORY_NAME'])
     @user = User.find_by(login: params[:user_login])

--- a/app/controllers/users/issues_controller.rb
+++ b/app/controllers/users/issues_controller.rb
@@ -4,5 +4,12 @@ class Users::IssuesController < ApplicationController
   def index
     @repository = Repository.find_by(name: ENV['REPOSITORY_NAME'])
     @user = User.find_by(login: params[:user_login])
+
+    @issues =
+      if params[:association] == 'assigned'
+        @user.assigned_issues
+      else
+        @user.issues
+      end
   end
 end

--- a/app/models/assign.rb
+++ b/app/models/assign.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Assign < ApplicationRecord
+  belongs_to :assignable, polymorphic: true
+  belongs_to :user
+end

--- a/app/models/github/issue.rb
+++ b/app/models/github/issue.rb
@@ -36,6 +36,12 @@ module GitHub
         issues.map { |issue| new(repository_id: repository.id, issue: convert_to_hash(issue)) }
       end
 
+      def assigned_by(repository, user)
+        client = GitHub::APIClient.new
+        issues = client.search_issues("repo:#{repository.name} is:issue assignee:#{user.login}")
+        issues.map { |issue| new(repository_id: repository.id, issue: convert_to_hash(issue)) }
+      end
+
       private
 
       def convert_to_hash(issue)

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -3,4 +3,7 @@
 class Issue < ApplicationRecord
   belongs_to :author, class_name: 'User', optional: true
   belongs_to :repository
+
+  has_many :assigns, as: :assignable, dependent: :destroy
+  has_many :assignees, through: :assigns, source: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,6 @@
 
 class User < ApplicationRecord
   has_many :issues, foreign_key: :author_id, inverse_of: :author # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_many :assigns, dependent: :destroy
+  has_many :assigned_issues, through: :assigns, source: :assignable, source_type: 'Issue'
 end

--- a/app/views/users/issues/index.html.slim
+++ b/app/views/users/issues/index.html.slim
@@ -20,7 +20,7 @@
       li.me-2
         = link_to '作成した Issue', users_issues_path(@user.login), class: 'inline-block p-4 text-blue-600 border-b-2 border-blue-600 rounded-t-lg active', aria: { current: 'page' }
       li.me-2
-        = link_to '担当した Issue', '#', class: 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300'
+        = link_to '担当した Issue', users_issues_path(@user.login, association: 'assigned'), class: 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300'
       li.me-2
         = link_to 'レビューした Issue', '#', class: 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300'
       li.me-2
@@ -28,7 +28,7 @@
       li.me-2
         = link_to '全て表示', '#', class: 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300'
 
-- if @user.issues.count.zero?
+- if @issues.count.zero?
   .max-w-screen-lg.mx-auto.w-full.text-center.mt-28.text-slate-700
     .font-medium.text-2xl
       | 表示可能なアイテムはありませんでした
@@ -38,8 +38,8 @@
       .relative.my-10.mx-10.overflow-x-auto.shadow-md.sm:rounded-lg
         .w-full.text-sm.text-left.rtl:text-right.text-gray-500
           .px-6.py-3.text-gray-50.font-semibold.bg-slate-700.border-b
-            = "Total #{@user.issues.count}"
-          - @user.issues.each do |issue|
+            = "Total #{@issues.count}"
+          - @issues.each do |issue|
             .bg-white.border-b.hover:bg-gray-100.px-6.py-3.font-bold.text-slate-700
               .w-fit.hover:text-blue-600
                 = issue.title

--- a/app/views/users/issues/index.html.slim
+++ b/app/views/users/issues/index.html.slim
@@ -18,7 +18,7 @@
   .mx-4.text-sm.font-semibold.text-center.text-gray-500.border-b.border-gray-300
     ul.flex.flex-wrap.pl-4
       li.me-2
-        = link_to '作成した Issue', user_issues_path(@user.login), class: 'inline-block p-4 text-blue-600 border-b-2 border-blue-600 rounded-t-lg active', aria: { current: 'page' }
+        = link_to '作成した Issue', users_issues_path(@user.login), class: 'inline-block p-4 text-blue-600 border-b-2 border-blue-600 rounded-t-lg active', aria: { current: 'page' }
       li.me-2
         = link_to '担当した Issue', '#', class: 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300'
       li.me-2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace :user, path: '/:user_login' do
+  namespace :users, path: '/:user_login' do
     resources :issues, only: %i[index]
   end
 end

--- a/db/migrate/20240823200443_create_assigns.rb
+++ b/db/migrate/20240823200443_create_assigns.rb
@@ -1,0 +1,10 @@
+class CreateAssigns < ActiveRecord::Migration[7.2]
+  def change
+    create_table :assigns do |t|
+      t.references :assignable, polymorphic: true, null: false
+      t.references :user,       foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_22_180024) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_23_200443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "assigns", force: :cascade do |t|
+    t.string "assignable_type", null: false
+    t.bigint "assignable_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assignable_type", "assignable_id"], name: "index_assigns_on_assignable"
+    t.index ["user_id"], name: "index_assigns_on_user_id"
+  end
 
   create_table "issues", force: :cascade do |t|
     t.string "title", null: false
@@ -51,6 +61,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_180024) do
     t.index ["login"], name: "index_users_on_login", unique: true
   end
 
+  add_foreign_key "assigns", "users"
   add_foreign_key "issues", "repositories"
   add_foreign_key "labels", "repositories"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,7 @@ Repository.destroy_all
 Label.destroy_all
 User.destroy_all
 Issue.destroy_all
+Assign.destroy_all
 
 # 初期データの投入
 repo_by_api = GitHub::Repository.find_by(name: 'fjordllc/bootcamp')
@@ -26,5 +27,11 @@ labels_by_api.map { |label| Label.create!(label.to_h) }
 user_by_api = GitHub::User.find_by(login: ENV['USER_LOGIN'])
 user = User.create!(user_by_api.to_h)
 
-issues = GitHub::Issue.created_by(repository, user)
-issues.map { |issue| Issue.create!(issue.to_h) }
+created_issues = GitHub::Issue.created_by(repository, user)
+created_issues.map { |issue| Issue.create!(issue.to_h) }
+
+assigned_issues = GitHub::Issue.assigned_by(repository, user)
+assigned_issues.map do |issue|
+  Issue.create!(issue.to_h) unless Issue.find_by(id: issue.id)
+  Assign.create!(assignable_type: 'Issue', assignable_id: issue.id, user:)
+end

--- a/spec/models/assign_spec.rb
+++ b/spec/models/assign_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Assign, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/assign_spec.rb
+++ b/spec/models/assign_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Assign, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/github/issue_spec.rb
+++ b/spec/models/github/issue_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe GitHub::Issue, type: :model do
       end
     end
   end
+
+  describe '.assigned_by' do
+    context '該当する Issue がある場合' do
+      it ' GitHub::Issue オブジェクトを要素に持つ Array を返すこと', vcr: { cassette_name: 'github/issue/assigned_by' } do
+        repository = FactoryBot.create(:repository, name: 'test/repository')
+        user = FactoryBot.create(:user, login: 'kimura')
+
+        issues = GitHub::Issue.assigned_by(repository, user)
+        expect(issues).not_to be_empty
+        expect(issues).to all(be_instance_of(GitHub::Issue))
+      end
+    end
+
+    context '該当する Issue がない場合' do
+      it '空の Array を返すこと', vcr: { cassette_name: 'github/issue/assigned_by_not_found' } do
+        repository = FactoryBot.create(:repository, name: 'test/repository')
+        user = FactoryBot.create(:user, login: 'not_found')
+
+        issues = GitHub::Issue.assigned_by(repository, user)
+        expect(issues).to be_empty
+      end
+    end
+  end
 end

--- a/spec/system/user/user_issues_spec.rb
+++ b/spec/system/user/user_issues_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'User::Issues', type: :system do
       create(:issue, :with_author, :with_repository, repository_id: 123, title: 'Issue B', author: kimura)
     end
 
-    visit user_issues_path('kimura')
+    visit users_issues_path('kimura')
 
     expect(page).to have_content 'Total 2'
     expect(page).to have_content 'Issue A'

--- a/spec/system/user/user_issues_spec.rb
+++ b/spec/system/user/user_issues_spec.rb
@@ -16,4 +16,18 @@ RSpec.describe 'User::Issues', type: :system do
     expect(page).to have_content 'Issue A'
     expect(page).to have_content 'Issue B'
   end
+
+  scenario 'ユーザーが担当した Issue を一覧表示する' do
+    create(:repository, id: 123, name: 'test/repository')
+    create(:user, login: 'kimura') do |kimura|
+      create(:issue, :with_author, :with_repository, repository_id: 123, title: 'Issue C') { |issue| issue.assignees << kimura }
+      create(:issue, :with_author, :with_repository, repository_id: 123, title: 'Issue D') { |issue| issue.assignees << kimura }
+    end
+
+    visit users_issues_path('kimura', association: 'assigned')
+
+    expect(page).to have_content 'Total 2'
+    expect(page).to have_content 'Issue C'
+    expect(page).to have_content 'Issue D'
+  end
 end

--- a/spec/vcr/github/issue/assigned_by.yml
+++ b/spec/vcr/github/issue/assigned_by.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:issue%20assignee:kimura
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 5.6.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 26 May 2024 20:44:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-05-29 04:06:58 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '27'
+      X-Ratelimit-Reset:
+      - '1716756354'
+      X-Ratelimit-Used:
+      - '3'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - C87A:3EDF45:36269CB:3736479:66539F46
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"items":[{"id":1,"number":123,"title":"issue_123","user":{"id":1},"labels":[{"id":1}],"created_at":"2000-01-01T09:00:00Z","updated_at":"2000-01-01T10:00:00Z"},{"id":2,"number":456,"title":"issue_456","user":{"id":1},"labels":[{"id":1}],"created_at":"2000-01-01T09:00:00Z","updated_at":"2000-01-01T10:00:00Z"}]}'
+  recorded_at: Sun, 26 May 2024 20:44:55 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr/github/issue/assigned_by_not_found.yml
+++ b/spec/vcr/github/issue/assigned_by_not_found.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:issue%20assignee:not_found
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.1.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Fri, 23 Aug 2024 19:36:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '300'
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-08-28 02:34:05 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      X-Ratelimit-Reset:
+      - '1724441832'
+      X-Ratelimit-Used:
+      - '1'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Server:
+      - github.com
+      X-Github-Request-Id:
+      - DAC2:293358:8B6C74:939119:66C8E4AC
+    body:
+      encoding: UTF-8
+      string: '{"message":"Validation Failed","errors":[{"message":"The listed users
+        cannot be searched either because the users do not exist or you do not have
+        permission to view the users.","resource":"Search","field":"q","code":"invalid"}],"documentation_url":"https://docs.github.com/v3/search/","status":"422"}'
+  recorded_at: Fri, 23 Aug 2024 19:36:12 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr/github/issue/assigned_by_with_not_found.yml
+++ b/spec/vcr/github/issue/assigned_by_with_not_found.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:issue%20assignee:not_found
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 5.6.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 26 May 2024 20:44:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-05-29 04:06:58 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '27'
+      X-Ratelimit-Reset:
+      - '1716756354'
+      X-Ratelimit-Used:
+      - '3'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - C87A:3EDF45:36269CB:3736479:66539F46
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":0,"items":[]}'
+  recorded_at: Sun, 26 May 2024 20:44:55 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Issue

- #71 
- #72 

## 概要

- GitHub API から ユーザーが担当した Issue を取得する機能を作成
- 初期データを投入できるようにした
- ユーザーが担当した Issue を一覧表示できるようにした
- テストの作成


## 変更前

無し

## 変更後

<img src="https://github.com/user-attachments/assets/848d3c77-f7ad-465c-8225-2e6c978ddb07" width="700" />