### PR TITLE
GitHub API から ユーザーがレビューした Issue を取得する機能の作成

### DIFF
--- a/app/models/github/issue.rb
+++ b/app/models/github/issue.rb
@@ -42,6 +42,16 @@ module GitHub
         issues.map { |issue| new(repository_id: repository.id, issue: convert_to_hash(issue)) }
       end
 
+      def reviewed_by(repository, user)
+        pull_requests = GitHub::PullRequest.reviewed_by(repository, user)
+        issues_number = pull_requests.flat_map(&:issues_number)
+        return [] if issues_number.empty?
+
+        client = GitHub::APIClient.new
+        issues = client.search_issues("repo:#{repository.name} is:issue #{issues_number.join(' ')}")
+        issues.map { |issue| new(repository_id: repository.id, issue: convert_to_hash(issue)) }
+      end
+
       private
 
       def convert_to_hash(issue)

--- a/app/models/github/pull_request.rb
+++ b/app/models/github/pull_request.rb
@@ -2,7 +2,7 @@
 
 module GitHub
   class PullRequest
-    attr_reader :id
+    attr_reader :id, :issues_number
 
     def initialize(repository_id:, pull_request: { id:, number:, issues_number:, created_at:, updated_at: })
       @id = pull_request[:id]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,6 +44,11 @@ assigned_pull_requests.each do |pull_request|
   Assign.create!(assignable_type: 'PullRequest', assignable_id: pull_request.id, user:)
 end
 
+reviewed_issues = GitHub::Issue.reviewed_by(repository, user)
+reviewed_issues.each do |issue|
+  Issue.create!(issue.to_h) unless Issue.find_by(id: issue.id)
+end
+
 reviews_pull_requests = GitHub::PullRequest.reviewed_by(repository, user)
 reviews_pull_requests.each do |pull_request|
   PullRequest.create!(pull_request.to_h)

--- a/spec/models/github/issue_spec.rb
+++ b/spec/models/github/issue_spec.rb
@@ -67,4 +67,27 @@ RSpec.describe GitHub::Issue, type: :model do
       end
     end
   end
+
+  describe '.reviewed_by' do
+    context '該当する Issue がある場合' do
+      it ' GitHub::Issue オブジェクトを要素に持つ Array を返すこと', vcr: { cassette_name: 'github/issue/reviewed_by' } do
+        repository = create(:repository, name: 'test/repository')
+        user = create(:user, login: 'kimura')
+
+        issues = GitHub::Issue.reviewed_by(repository, user)
+        expect(issues).not_to be_empty
+        expect(issues).to all(be_instance_of(GitHub::Issue))
+      end
+    end
+
+    context '該当する Issue がない場合' do
+      it '空の Array を返すこと', vcr: { cassette_name: 'github/issue/reviewed_by_with_not_found' } do
+        repository = create(:repository, name: 'test/repository')
+        user = create(:user, login: 'not_found')
+
+        issues = GitHub::Issue.reviewed_by(repository, user)
+        expect(issues).to be_empty
+      end
+    end
+  end
 end

--- a/spec/vcr/github/issue/reviewed_by.yml
+++ b/spec/vcr/github/issue/reviewed_by.yml
@@ -1,0 +1,159 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:pr%20reviewed-by:kimura%20review:approved%20-assignee:kimura
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 5.6.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 09 Jun 2024 16:21:24 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-06-16 19:30:48 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '28'
+      X-Ratelimit-Reset:
+      - '1717950115'
+      X-Ratelimit-Used:
+      - '2'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - 8E10:2FF0EB:1EED7A9:1FE3A57:6665D683
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"items":[{"id":1,"number":100,"body":"## Issue\r\n\r\n- https://github.com/test/repository/issues/11\r\n\r\n## 概要","created_by":"2000/01/01 09:00:00","updated_by":"2000/01/01 10:00:00"},{"id":2,"number":200,"body":"## Issue\r\n\r\n- https://github.com/test/repository/issues/12\r\n\r\n## 概要","created_by":"2000/01/01 09:00:00","updated_by":"2000/01/01 10:00:00"}]}'
+  recorded_at: Sun, 09 Jun 2024 16:21:24 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:issue%2011%2012
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 5.6.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 09 Jun 2024 16:21:24 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-06-16 19:30:48 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '27'
+      X-Ratelimit-Reset:
+      - '1717950115'
+      X-Ratelimit-Used:
+      - '3'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - B97A:3028A6:1EF2791:1FE89FE:6665D684
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"items":[{"id":11,"number":11,"title":"issue_11","user":{"id":1},"labels":[{"id":1}],"created_at":"2000-01-01T09:00:00Z","updated_at":"2000-01-01T10:00:00Z"},{"id":12,"number":12,"title":"issue_12","user":{"id":1},"labels":[{"id":1}],"created_at":"2000-01-01T09:00:00Z","updated_at":"2000-01-01T10:00:00Z"}]}'
+  recorded_at: Sun, 09 Jun 2024 16:21:24 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr/github/issue/reviewed_by_with_not_found.yml
+++ b/spec/vcr/github/issue/reviewed_by_with_not_found.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:pr%20reviewed-by:not_found%20review:approved%20-assignee:not_found
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 5.6.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 09 Jun 2024 16:21:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '300'
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-06-16 19:30:48 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '26'
+      X-Ratelimit-Reset:
+      - '1717950115'
+      X-Ratelimit-Used:
+      - '4'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - B302:3B329E:A55007:A9AA47:6665D69C
+    body:
+      encoding: UTF-8
+      string: '{"total_count":0,"items":[]}'
+  recorded_at: Sun, 09 Jun 2024 16:21:48 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Issue

- #74 

## 概要

- GitHub API から ユーザーがレビューした Issue を取得する機能を作成
- 初期データを投入できるようにした
- テストの作成


## 変更前 / 変更後

動作上の見た目の変更は無し