### PR TITLE
リポジトリの Wiki を取得する機能の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'turbo-rails'
 gem 'faraday-multipart', require: false
 gem 'faraday-retry'
 gem 'font-awesome-sass'
+gem 'git'
 gem 'high_voltage'
 gem 'octokit'
 gem 'slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,11 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     font-awesome-sass (6.5.2)
       sassc (~> 2.0)
+    git (2.1.1)
+      activesupport (>= 5.0)
+      addressable (~> 2.8)
+      process_executer (~> 1.1)
+      rchardet (~> 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.1)
@@ -192,6 +197,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.7)
+    process_executer (1.1.0)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
@@ -237,6 +243,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rchardet (1.8.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -393,6 +400,7 @@ DEPENDENCIES
   faraday-multipart
   faraday-retry
   font-awesome-sass
+  git
   high_voltage
   importmap-rails
   octokit

--- a/app/models/git/wiki.rb
+++ b/app/models/git/wiki.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Git
+  class Wiki
+    include ActiveSupport::Configurable
+    config_accessor :github_url, instance_accessor: false
+
+    attr_reader :first_commit_hash
+
+    def initialize(repository_id:, file_data: { user_id:, title:, first_commit_hash:, created_at:, updated_at: })
+      @repository_id = repository_id
+      @author_id = file_data[:user_id]
+      @title = file_data[:title]
+      @first_commit_hash = file_data[:first_commit_hash]
+      @created_at = file_data[:created_at]
+      @updated_at = file_data[:updated_at]
+    end
+
+    def to_h
+      { repository_id: @repository_id,
+        author_id: @author_id,
+        title: @title,
+        first_commit_hash: @first_commit_hash,
+        created_at: @created_at,
+        updated_at: @updated_at }
+    end
+
+    class << self
+      def created_by(repository, user)
+        Dir.mktmpdir do |dir|
+          Git.clone("#{github_url}/#{repository.name}.wiki.git", dir)
+
+          git = Git.open dir
+          wikis = git.lib.ls_files
+
+          wikis.filter_map do |file_name, _|
+            file_log = git.log.object("#{dir}/#{file_name}")
+            next unless [user.login, user.name].include? file_log.last.author.name
+
+            new(repository_id: repository.id, file_data: convert_to_hash(user, file_name, file_log))
+          end
+        rescue Git::Error => e
+          log_error(e)
+          []
+        end
+      end
+
+      private
+
+      def convert_to_hash(user, file_name, file_log)
+        { user_id: user.id,
+          title: file_name.delete_suffix('.md'),
+          first_commit_hash: file_log.last.sha,
+          created_at: file_log.last.author_date,
+          updated_at: file_log.first.author_date }
+      end
+
+      def log_error(exception)
+        # NOTE: exception の例
+        #       - fatal: repository 'https://github.com/sample/repository.wiki.git/' not found
+        #       - fatal: unable to access 'https://github.com/sample/repository.wiki.git/': Could not resolve host: github.com
+        Rails.logger.error "[Git] #{exception.result.stderr}"
+      end
+    end
+  end
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -6,7 +6,7 @@ class Issue < ApplicationRecord
 
   has_many :assigns, as: :assignable, dependent: :destroy
   has_many :assignees, through: :assigns, source: :user
-  
+
   has_many :resolutions, dependent: :destroy
   has_many :pull_requests, through: :resolutions, source: :pull_request
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -4,4 +4,5 @@ class Repository < ApplicationRecord
   has_many :labels, dependent: :destroy
   has_many :issues, dependent: :destroy
   has_many :pull_requests, dependent: :destroy
+  has_many :wikis, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   has_many :issues, foreign_key: :author_id, inverse_of: :author # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_many :wikis, foreign_key: :author_id, inverse_of: :author, dependent: :destroy
 
   has_many :assigns, dependent: :destroy
   has_many :assigned_issues, through: :assigns, source: :assignable, source_type: 'Issue'

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Wiki < ApplicationRecord
+  belongs_to :author, class_name: 'User'
+  belongs_to :repository
+end

--- a/config/initializers/git.rb
+++ b/config/initializers/git.rb
@@ -1,0 +1,5 @@
+Rails.configuration.to_prepare do
+  Git::Wiki.configure do |config|
+    config.github_url = ENV['GITHUB_URL']
+  end
+end

--- a/db/migrate/20240825230328_create_wikis.rb
+++ b/db/migrate/20240825230328_create_wikis.rb
@@ -1,0 +1,13 @@
+class CreateWikis < ActiveRecord::Migration[7.2]
+  def change
+    create_table :wikis do |t|
+      t.references :repository,    null: false, foreign_key: true
+      t.references :author,        null: false, foreign_key: { to_table: :users }
+      t.string :title,             null: false
+      t.string :first_commit_hash, null: false
+
+      t.timestamps
+    end
+    add_index :wikis, %i[repository_id first_commit_hash], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_25_213859) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_25_230328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,18 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_25_213859) do
     t.index ["login"], name: "index_users_on_login", unique: true
   end
 
+  create_table "wikis", force: :cascade do |t|
+    t.bigint "repository_id", null: false
+    t.bigint "author_id", null: false
+    t.string "title", null: false
+    t.string "first_commit_hash", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_wikis_on_author_id"
+    t.index ["repository_id", "first_commit_hash"], name: "index_wikis_on_repository_id_and_first_commit_hash", unique: true
+    t.index ["repository_id"], name: "index_wikis_on_repository_id"
+  end
+
   add_foreign_key "assigns", "users"
   add_foreign_key "issues", "repositories"
   add_foreign_key "labels", "repositories"
@@ -98,4 +110,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_25_213859) do
   add_foreign_key "resolutions", "pull_requests"
   add_foreign_key "reviews", "pull_requests"
   add_foreign_key "reviews", "users"
+  add_foreign_key "wikis", "repositories"
+  add_foreign_key "wikis", "users", column: "author_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,7 @@ Assign.destroy_all
 PullRequest.destroy_all
 Review.destroy_all
 Resolution.destroy_all
+Wiki.destroy_all
 
 # 初期データの投入
 repo_by_api = GitHub::Repository.find_by(name: 'fjordllc/bootcamp')
@@ -60,4 +61,9 @@ reviews_pull_requests.each do |pull_request|
   pull_request.resolutions.each do |resolution|
     Resolution.create!(resolution) unless Resolution.find_by(resolution)
   end
+end
+
+created_wikis = Git::Wiki.created_by(repository, user)
+created_wikis.each do |wiki|
+  Wiki.create!(wiki.to_h)
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :user do
+  factory :user, aliases: [:author] do
     sequence(:login) { |n| "tester#{n}" }
     avatar_url { 'https://example.com/avatar.png' }
   end

--- a/spec/factories/wikis.rb
+++ b/spec/factories/wikis.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :wiki do
+    sequence(:title) { |n| "Wiki#{n}" }
+    first_commit_hash { Digest::SHA1.hexdigest(rand(100).to_s) }
+
+    trait :with_repository do
+      association :repository
+    end
+
+    trait :with_author do
+      association :author
+    end
+  end
+end

--- a/spec/models/git/wiki_spec.rb
+++ b/spec/models/git/wiki_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Git::Wiki, type: :model do
       end
 
       it 'ログに出力すること' do
-        expect(Rails.logger).to receive(:error).with("[Git] fatal: リポジトリ '#{@tmpdir_realpath}/not_found_repository.wiki.git' は存在しません")
+        expect(Rails.logger).to receive(:error)
         Git::Wiki.created_by(@repository, @user)
       end
     end

--- a/spec/models/git/wiki_spec.rb
+++ b/spec/models/git/wiki_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Git::Wiki, type: :model do
+  describe '#to_h' do
+    it '自身をハッシュ(連想配列)へ変換して返すこと' do
+      wiki = Git::Wiki.new(repository_id: 123, file_data: { user_id: 111,
+                                                            title: '議事録',
+                                                            first_commit_hash: 'aaabbb',
+                                                            created_at: '2024-03-03',
+                                                            updated_at: '2024-04-04' })
+
+      expect(wiki.to_h).to eq({ repository_id: 123,
+                                author_id: 111,
+                                title: '議事録',
+                                first_commit_hash: 'aaabbb',
+                                created_at: '2024-03-03',
+                                updated_at: '2024-04-04' })
+    end
+  end
+
+  describe '.created_by' do
+    before do
+      @tmpdir_realpath = create_dummy_repository_wiki
+      allow(Git::Wiki).to receive(:github_url).and_return(@tmpdir_realpath)
+    end
+
+    def create_dummy_repository_wiki
+      tmpdir = Dir.mktmpdir
+      tmpdir_realpath = File.realpath tmpdir
+
+      Dir.chdir(tmpdir_realpath) do
+        git = Git.init('test/repository.wiki.git')
+        git.config('user.name', 'kimura')
+
+        File.write('test/repository.wiki.git/test.txt', 'test')
+        git.add('test.txt')
+        git.commit('first commit')
+      end
+
+      tmpdir_realpath
+    end
+
+    after do
+      FileUtils.remove_entry_secure @tmpdir_realpath
+    end
+
+    context '該当する Wiki がある場合' do
+      it 'Git::Wiki オブジェクトを要素に持つ Array を返すこと' do
+        repository = create(:repository, name: 'test/repository')
+        user = create(:user, login: 'kimura')
+
+        wikis = Git::Wiki.created_by(repository, user)
+        expect(wikis).not_to be_empty
+        expect(wikis).to all(be_instance_of(Git::Wiki))
+      end
+    end
+
+    context '該当する Wiki がない場合' do
+      it '空の Array を返すこと' do
+        repository = create(:repository, name: 'test/repository')
+        user = create(:user, login: 'hajime')
+
+        wikis = Git::Wiki.created_by(repository, user)
+        expect(wikis).to be_empty
+      end
+    end
+
+    context 'エラーが発生した場合' do
+      before do
+        @repository = create(:repository, name: 'not_found_repository')
+        @user = create(:user, login: 'kimura')
+      end
+
+      it '空の Array を返すこと' do
+        wikis = Git::Wiki.created_by(@repository, @user)
+        expect(wikis).to be_empty
+      end
+
+      it 'ログに出力すること' do
+        expect(Rails.logger).to receive(:error).with("[Git] fatal: リポジトリ '#{@tmpdir_realpath}/not_found_repository.wiki.git' は存在しません")
+        Git::Wiki.created_by(@repository, @user)
+      end
+    end
+  end
+end

--- a/spec/models/git/wiki_spec.rb
+++ b/spec/models/git/wiki_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Git::Wiki, type: :model do
       Dir.chdir(tmpdir_realpath) do
         git = Git.init('test/repository.wiki.git')
         git.config('user.name', 'kimura')
+        git.config('user.email', 'kimura@email.com')
 
         File.write('test/repository.wiki.git/test.txt', 'test')
         git.add('test.txt')

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Wiki, type: :model do
+  it '有効なファクトリを持つこと' do
+    wiki = build(:wiki, :with_repository, :with_author)
+    expect(wiki).to be_valid
+  end
+end


### PR DESCRIPTION
## Issue

- #77 

## 概要

- GitHub から Wiki をクローンし、 ユーザーが作成した Wiki を取得する機能を作成
- テストの作成
- 初期データを投入できるようにした


## 変更前 / 変更後

動作上の見た目の変更は無し