### PR TITLE
ユーザーの取り組みの一覧表示を作成

### DIFF
--- a/app/controllers/concerns/settable.rb
+++ b/app/controllers/concerns/settable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Settable
+  extend ActiveSupport::Concern
+
+  def set_repository
+    @repository = Repository.find_by(name: ENV['REPOSITORY_NAME'])
+  end
+
+  def set_user
+    @user = User.find_by(login: params[:user_login])
+  end
+end

--- a/app/controllers/users/contributions_controller.rb
+++ b/app/controllers/users/contributions_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Users::ContributionsController < ApplicationController
+  def index
+    @repository = Repository.find_by(name: ENV['REPOSITORY_NAME'])
+    @user = User.find_by(login: params[:user_login])
+    @issues = @user.issues.order(:created_at)
+    @assigned_issues = @user.assigned_issues.order(:created_at)
+    @reviewed_issues = @user.reviewed_issues.order(:created_at)
+    @wikis = @user.wikis.order(:created_at)
+  end
+end

--- a/app/controllers/users/contributions_controller.rb
+++ b/app/controllers/users/contributions_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class Users::ContributionsController < ApplicationController
+  include Settable
+  before_action :set_repository, only: %i[index]
+  before_action :set_user, only: %i[index]
+
   def index
-    @repository = Repository.find_by(name: ENV['REPOSITORY_NAME'])
-    @user = User.find_by(login: params[:user_login])
     @issues = @user.issues.order(:created_at)
     @assigned_issues = @user.assigned_issues.order(:created_at)
     @reviewed_issues = @user.reviewed_issues.order(:created_at)

--- a/app/controllers/users/issues_controller.rb
+++ b/app/controllers/users/issues_controller.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Users::IssuesController < ApplicationController
-  def index
-    @repository = Repository.find_by(name: ENV['REPOSITORY_NAME'])
-    @user = User.find_by(login: params[:user_login])
+  include Settable
+  before_action :set_repository, only: %i[index]
+  before_action :set_user, only: %i[index]
 
+  def index
     @issues =
       case params[:association]
       when 'assigned'

--- a/app/controllers/users/wikis_controller.rb
+++ b/app/controllers/users/wikis_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class Users::WikisController < ApplicationController
+  include Settable
+  before_action :set_repository, only: %i[index]
+  before_action :set_user, only: %i[index]
+
   def index
-    @repository = Repository.find_by(name: ENV['REPOSITORY_NAME'])
-    @user = User.find_by(login: params[:user_login])
     @wikis = @user.wikis.order(:created_at)
   end
 end

--- a/app/decorators/issue_decorator.rb
+++ b/app/decorators/issue_decorator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module IssueDecorator
+  def point
+    labels.pluck(:name).sum(&:to_i)
+  end
+end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -4,10 +4,19 @@ class PullRequest < ApplicationRecord
   belongs_to :repository
 
   has_many :assigns, as: :assignable, dependent: :destroy
+  has_many :assignees, through: :assigns, source: :user
 
   has_many :reviews, dependent: :destroy
   has_many :reviewers, through: :reviews, source: :user
 
   has_many :resolutions, dependent: :destroy
   has_many :issues, through: :resolutions, source: :issue
+
+  def assignee?(user)
+    assignees.include?(user)
+  end
+
+  def reviewer?(user)
+    reviewers.include?(user)
+  end
 end

--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -10,4 +10,4 @@
       li.me-2
         = link_to '作成した Wiki', users_wikis_path(user.login), class: 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300'
       li.me-2
-        = link_to '全て表示', '#', class: 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300'
+        = link_to '全て表示', users_contributions_path(user.login), class: 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300'

--- a/app/views/users/contributions/_list.html.slim
+++ b/app/views/users/contributions/_list.html.slim
@@ -1,0 +1,11 @@
+.pt-2.ml-4.mb-5
+  .mb-3
+    h3.text-2xl.text-slate-600.font-semibold.mb-2
+      = list_header
+    p.font-medium.text-slate-700
+      = content
+
+  ul.ml-2.space-y-2.font-semibold.text-slate-700.list-disc.list-inside
+    - items.each do |item|
+      li
+        = item.title

--- a/app/views/users/contributions/_table.html.slim
+++ b/app/views/users/contributions/_table.html.slim
@@ -1,0 +1,42 @@
+.mb-10
+  h2.text-2xl.text-slate-600.font-bold.border-b.border-gray-400.pb-2.mb-3
+    = table_header
+
+  .relative.mt-4.mx-3.overflow-x-auto.shadow-md.sm:rounded-lg
+    table.w-full.text-sm.text-left.rtl:text-right.text-gray-500
+      thead.text-gray-50.bg-slate-600.border-b.border-gray-400
+        tr
+          th.px-6.py-3(col='col')
+            | Point
+          th.px-6.py-3(col='col')
+            | Issue
+          th.px-6.py-3(col='col')
+            | PR
+      tbody
+        - if issues.any?
+          - issues.each do |issue|
+            tr.font-semibold.odd:bg-gray-200.text-slate-800.even:bg-gray-100.border-b.border-gray-400
+              td.px-6.py-3
+                = issue.point || '-'
+              td.px-6.py-3
+                = issue.title
+              td.px-6.py-3
+                - issue.pull_requests.each do |pull_request|
+                  - if (table_header == 'Pull Request' && pull_request.assignee?(user)) || (table_header == 'Review' && pull_request.reviewer?(user))
+                    = "##{pull_request.number}"
+                    br
+        - else
+            tr.font-semibold.bg-gray-200.text-slate-800.border-b.border-gray-400
+              td.px-6.py-3
+                | -
+              td.px-6.py-3
+                | -
+              td.px-6.py-3
+                | -
+      tfoot
+        tr.bg-slate-600.font-semibold.text-gray-50
+          th.px-6.py-3
+            = issues.sum(&:point)
+          td.px-6.py-3
+            | Total
+          td.px-6.py-3

--- a/app/views/users/contributions/index.html.slim
+++ b/app/views/users/contributions/index.html.slim
@@ -1,0 +1,30 @@
+= render 'users/page_header', repository: @repository, user: @user
+= render 'users/page_tabs', user: @user
+
+div
+  .px-10.pt-5.pb-10.flex-grow.max-w-screen-lg.mx-auto
+    .flex.justify-end
+      button.mr-4.w-fit.px-4.text-white.text-sm.bg-zinc-500.hover:bg-zinc-700.focus:ring-4.focus:outline-none.focus:ring-zinc-700.font-medium.rounded-lg.py-2.5(data-tooltip-target="tooltip-markdown-copy")
+        span.inline-flex.items-center
+          i.fa-regular.fa-copy.mr-2
+          | Markdown をコピー
+      #tooltip-markdown-copy.absolute.z-50.invisible.inline-block.px-3.py-2.text-gray-50.text-xs.font-medium.bg-zinc-700.border.border-black.rounded-lg.shadow-sm.opacity-0.tooltip(role="tooltip")
+        | 以下の一覧を Markdown 記法でクリップボードへコピーします
+        .tooltip-arrow.bg-zinc-700(data-popper-arrow)
+      button.w-fit.px-4.text-white.text-sm.bg-zinc-500.hover:bg-zinc-700.focus:ring-4.focus:outline-none.focus:ring-zinc-700.font-medium.rounded-lg.py-2.5(data-tooltip-target="tooltip-url-copy")
+        span.inline-flex.items-center
+          i.fa-regular.fa-copy.mr-2
+          | URL をコピー
+      #tooltip-url-copy.absolute.z-50.invisible.inline-block.px-3.py-2.text-gray-50.text-xs.font-medium.bg-zinc-700.rounded-lg.shadow-sm.opacity-0.tooltip(role="tooltip")
+        | この画面の URL をクリップボードへコピーします
+        .tooltip-arrow.bg-zinc-700(data-popper-arrow)
+
+    div(data-clipboard-target='allIssuesTable')
+      = render 'table', table_header: 'Pull Request', issues: @assigned_issues, user: @user
+      = render 'table', table_header: 'Review',       issues: @reviewed_issues, user: @user
+
+      - if @issues.any? || @wikis.any?
+        h2.text-2xl.text-slate-600.font-bold.border-b.border-gray-400.pb-2.mb-3
+          | その他
+        = render 'list', list_header: 'Issue', content: 'バグ発見の報告や改善提案を目的として作成したIssueです。', items: @issues if @issues.any?
+        = render 'list', list_header: 'Wiki', content: '議事録や作業効率化を目的として作成したWikiページです。', items: @wikis if @wikis.any?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   namespace :users, path: '/:user_login' do
     resources :issues, only: %i[index]
     resources :wikis, only: %i[index]
+    resources :contributions, only: %i[index]
   end
 end

--- a/spec/decorators/issue_decorator_spec.rb
+++ b/spec/decorators/issue_decorator_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IssueDecorator do
+  describe '#point' do
+    before do
+      create(:repository, id: 123)
+    end
+
+    context 'Issue にラベルが貼られていない場合' do
+      it 'ゼロを返すこと' do
+        issue = create(:issue, :with_author, :with_repository, repository_id: 123)
+
+        decorator_issue = ActiveDecorator::Decorator.instance.decorate(issue)
+        expect(decorator_issue.point).to eq 0
+      end
+    end
+
+    context 'Issue にラベルが貼られている場合' do
+      it 'ストーリーポイントとなるラベルがあれば、そのポイントを返すこと' do
+        issue = create(:issue, :with_author, :with_repository, repository_id: 123)
+        issue.labels << create(:label, :with_repository, repository_id: 123, name: '1')
+        issue.labels << create(:label, :with_repository, repository_id: 123, name: 'good first issue')
+
+        decorator_issue = ActiveDecorator::Decorator.instance.decorate(issue)
+        expect(decorator_issue.point).to eq 1
+      end
+
+      it 'ストーリーポイントとなるラベルがなけれが、ゼロを返すこと' do
+        issue = create(:issue, :with_author, :with_repository, repository_id: 123)
+        issue.labels << create(:label, :with_repository, repository_id: 123, name: 'good first issue')
+
+        decorator_issue = ActiveDecorator::Decorator.instance.decorate(issue)
+        expect(decorator_issue.point).to eq 0
+      end
+    end
+  end
+end

--- a/spec/system/user/user_contributions_spec.rb
+++ b/spec/system/user/user_contributions_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'User::Contributions', type: :system do
+  scenario 'ユーザーの 作成/担当/レビューした Issue とそれと紐付いた PullRequest 、Wiki を一覧表示する' do
+    create(:repository, id: 123, name: 'test/repository')
+    kimura = create(:user, login: 'kimura')
+
+    create(:issue, :with_author, :with_repository, repository_id: 123, title: 'キムラが担当した Issue') do |issue|
+      issue.assignees << kimura
+      issue.pull_requests << create(:pull_request, :with_repository, repository_id: 123, number: 111) { |pr| pr.assignees << kimura }
+    end
+
+    create(:issue, :with_author, :with_repository, repository_id: 123, title: 'キムラがレビューした Issue') do |issue|
+      issue.pull_requests << create(:pull_request, :with_repository, repository_id: 123, number: 222) { |pr| pr.reviewers << kimura }
+    end
+
+    create(:issue, :with_author, :with_repository, repository_id: 123, title: 'キムラが作成した Issue', author: kimura)
+    create(:wiki, :with_repository, repository_id: 123, title: 'キムラが作成した Wiki', author: kimura)
+
+    visit users_contributions_path(kimura.login)
+
+    expect(page).to have_button('Markdown をコピー')
+    expect(page).to have_button('URL をコピー')
+    expect(page).to have_content('キムラが担当した Issue')
+    expect(page).to have_content('#111')
+    expect(page).to have_content('キムラがレビューした Issue')
+    expect(page).to have_content('#222')
+    expect(page).to have_content('キムラが作成した Issue')
+    expect(page).to have_content('キムラが作成した Wiki')
+  end
+end


### PR DESCRIPTION
## Issue

- #94  

## 概要

- Issue に付与されたラベルからポイントを算出できるようにした
- ユーザーの取り組みの一覧表示画面を作成
- コントローラの重複処理を共通化
- テストの作成


## 変更前 

無し


## 変更後

<img src="https://github.com/user-attachments/assets/f51e0dd6-7544-4441-bf96-43ac2e3ea3f0" />
