### PR TITLE
ユーザーの取り組みの一覧表示を Markdown 形式でクリップボードにコピーする機能を実装

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from '@hotwired/stimulus'
+import { NodeHtmlMarkdown } from 'node-html-markdown'
+
+// Connects to data-controller="copy-to-clipboard"
+export default class extends Controller {
+  static targets = [
+    'allIssuesTable',
+    'markdownButtonMessage',
+    'markdownButtonSuccessMessage'
+  ]
+
+  markdownCopy() {
+    const markdonwText = NodeHtmlMarkdown.translate(
+      this.allIssuesTableTarget.outerHTML,
+      { bulletMarker: '-' }
+    )
+    navigator.clipboard.writeText(markdonwText).then(() => {
+      this.markdownButtonMessageTarget.classList.add('hidden')
+      this.markdownButtonSuccessMessageTarget.classList.remove('hidden')
+
+      // reset to default state
+      setTimeout(() => {
+        this.markdownButtonMessageTarget.classList.remove('hidden')
+        this.markdownButtonSuccessMessageTarget.classList.add('hidden')
+      }, 2000)
+    })
+  }
+}

--- a/app/views/users/contributions/index.html.slim
+++ b/app/views/users/contributions/index.html.slim
@@ -1,17 +1,20 @@
 = render 'users/page_header', repository: @repository, user: @user
 = render 'users/page_tabs', user: @user
 
-div
+div(data-controller='clipboard')
   .px-10.pt-5.pb-10.flex-grow.max-w-screen-lg.mx-auto
     .flex.justify-end
-      button.mr-4.w-fit.px-4.text-white.text-sm.bg-zinc-500.hover:bg-zinc-700.focus:ring-4.focus:outline-none.focus:ring-zinc-700.font-medium.rounded-lg.py-2.5(data-tooltip-target="tooltip-markdown-copy")
-        span.inline-flex.items-center
+      button.mr-4.w-48.px-4.text-white.text-sm.bg-zinc-700.hover:bg-zinc-600.focus:ring-4.focus:outline-none.focus:ring-zinc-600.font-medium.rounded-lg.py-2.5(data-action='clipboard#markdownCopy' data-tooltip-target="tooltip-markdown-copy")
+        span.inline-flex.items-center(data-clipboard-target='markdownButtonMessage')
           i.fa-regular.fa-copy.mr-2
+          | Markdown をコピー
+        span.hidden.inline-flex.items-center(data-clipboard-target='markdownButtonSuccessMessage')
+          i.fa-solid.fa-check.w-3.me-1.5.mr-2
           | Markdown をコピー
       #tooltip-markdown-copy.absolute.z-50.invisible.inline-block.px-3.py-2.text-gray-50.text-xs.font-medium.bg-zinc-700.border.border-black.rounded-lg.shadow-sm.opacity-0.tooltip(role="tooltip")
         | 以下の一覧を Markdown 記法でクリップボードへコピーします
         .tooltip-arrow.bg-zinc-700(data-popper-arrow)
-      button.w-fit.px-4.text-white.text-sm.bg-zinc-500.hover:bg-zinc-700.focus:ring-4.focus:outline-none.focus:ring-zinc-700.font-medium.rounded-lg.py-2.5(data-tooltip-target="tooltip-url-copy")
+      button.w-36.px-4.text-white.text-sm.bg-zinc-700.hover:bg-zinc-600.focus:ring-4.focus:outline-none.focus:ring-zinc-600.font-medium.rounded-lg.py-2.5(data-tooltip-target="tooltip-url-copy")
         span.inline-flex.items-center
           i.fa-regular.fa-copy.mr-2
           | URL をコピー

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,17 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 
 # not default
 pin "flowbite", to: "https://cdn.jsdelivr.net/npm/flowbite@2.5.1/dist/flowbite.turbo.min.js"
+# node-html-markdown
+pin "node-html-markdown", to: "https://ga.jspm.io/npm:node-html-markdown@1.3.0/dist/index.js"
+pin "boolbase", to: "https://ga.jspm.io/npm:boolbase@1.0.0/index.js"
+pin "css-select", to: "https://ga.jspm.io/npm:css-select@5.1.0/lib/index.js"
+pin "css-what", to: "https://ga.jspm.io/npm:css-what@6.1.0/lib/es/index.js"
+pin "dom-serializer", to: "https://ga.jspm.io/npm:dom-serializer@2.0.0/lib/index.js"
+pin "domelementtype", to: "https://ga.jspm.io/npm:domelementtype@2.3.0/lib/index.js"
+pin "domhandler", to: "https://ga.jspm.io/npm:domhandler@5.0.3/lib/index.js"
+pin "domutils", to: "https://ga.jspm.io/npm:domutils@3.1.0/lib/index.js"
+pin "entities", to: "https://ga.jspm.io/npm:entities@4.5.0/lib/index.js"
+pin "he", to: "https://ga.jspm.io/npm:he@1.2.0/he.js"
+pin "node-html-parser", to: "https://ga.jspm.io/npm:node-html-parser@6.1.5/dist/index.js"
+pin "nth-check", to: "https://ga.jspm.io/npm:nth-check@2.1.1/lib/index.js"
+pin "process", to: "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/process-production.js"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "flowbite": "^2.5.1"
+    "flowbite": "^2.5.1",
+    "node-html-markdown": "^1.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,6 +267,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
@@ -369,6 +374,22 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
@@ -456,6 +477,41 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -995,6 +1051,11 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz"
@@ -1311,6 +1372,21 @@ nice-try@^1.0.4:
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-html-markdown@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-1.3.0.tgz"
+  integrity sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==
+  dependencies:
+    node-html-parser "^6.1.1"
+
+node-html-parser@^6.1.1:
+  version "6.1.13"
+  resolved "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz"
+  integrity sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
+
 normalize-package-data@^2.3.2:
   version "2.5.0"
   resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz"
@@ -1335,6 +1411,13 @@ npm-run-all@^4.1.5:
     read-pkg "^3.0.0"
     shell-quote "^1.6.1"
     string.prototype.padend "^3.0.0"
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
 
 object-inspect@^1.13.1:
   version "1.13.2"


### PR DESCRIPTION
## Issue

- #98   

## 概要

- `Markdown をコピーボタン` のクリックで、ユーザーの取り組みの一覧表示を Markdown 形式でクリップボードにコピーする機能を実装


## 変更前 / 変更後

動作上の見た目の変更は無し
