### PR TITLE
ユーザーの取り組みの一覧表示の URL をクリップボードへコピーする機能を実装

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
     'markdownButtonMessage',
     'markdownButtonSuccessMessage',
     'urlButtonMessage',
-    'urlButtonSuccessMessage',
+    'urlButtonSuccessMessage'
   ]
 
   markdownCopy() {

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -6,7 +6,9 @@ export default class extends Controller {
   static targets = [
     'allIssuesTable',
     'markdownButtonMessage',
-    'markdownButtonSuccessMessage'
+    'markdownButtonSuccessMessage',
+    'urlButtonMessage',
+    'urlButtonSuccessMessage',
   ]
 
   markdownCopy() {
@@ -22,6 +24,19 @@ export default class extends Controller {
       setTimeout(() => {
         this.markdownButtonMessageTarget.classList.remove('hidden')
         this.markdownButtonSuccessMessageTarget.classList.add('hidden')
+      }, 2000)
+    })
+  }
+
+  urlCopy() {
+    navigator.clipboard.writeText(document.location.href).then(() => {
+      this.urlButtonMessageTarget.classList.add('hidden')
+      this.urlButtonSuccessMessageTarget.classList.remove('hidden')
+
+      // reset to default state
+      setTimeout(() => {
+        this.urlButtonMessageTarget.classList.remove('hidden')
+        this.urlButtonSuccessMessageTarget.classList.add('hidden')
       }, 2000)
     })
   }

--- a/app/views/users/contributions/index.html.slim
+++ b/app/views/users/contributions/index.html.slim
@@ -14,9 +14,12 @@ div(data-controller='clipboard')
       #tooltip-markdown-copy.absolute.z-50.invisible.inline-block.px-3.py-2.text-gray-50.text-xs.font-medium.bg-zinc-700.border.border-black.rounded-lg.shadow-sm.opacity-0.tooltip(role="tooltip")
         | 以下の一覧を Markdown 記法でクリップボードへコピーします
         .tooltip-arrow.bg-zinc-700(data-popper-arrow)
-      button.w-36.px-4.text-white.text-sm.bg-zinc-700.hover:bg-zinc-600.focus:ring-4.focus:outline-none.focus:ring-zinc-600.font-medium.rounded-lg.py-2.5(data-tooltip-target="tooltip-url-copy")
-        span.inline-flex.items-center
+      button.w-36.px-4.text-white.text-sm.bg-zinc-700.hover:bg-zinc-600.focus:ring-4.focus:outline-none.focus:ring-zinc-600.font-medium.rounded-lg.py-2.5(data-action='clipboard#urlCopy' data-tooltip-target="tooltip-url-copy")
+        span.inline-flex.items-center(data-clipboard-target='urlButtonMessage')
           i.fa-regular.fa-copy.mr-2
+          | URL をコピー
+        span.hidden.inline-flex.items-center(data-clipboard-target='urlButtonSuccessMessage')
+          i.fa-solid.fa-check.w-3.me-1.5.mr-2
           | URL をコピー
       #tooltip-url-copy.absolute.z-50.invisible.inline-block.px-3.py-2.text-gray-50.text-xs.font-medium.bg-zinc-700.rounded-lg.shadow-sm.opacity-0.tooltip(role="tooltip")
         | この画面の URL をクリップボードへコピーします


### PR DESCRIPTION
## Issue

- #99 

## 概要

- `URL をコピーボタン` のクリックで、ユーザーの取り組みの一覧表示の URL をクリップボードにコピーする機能を実装


## 変更前 / 変更後

動作上の見た目の変更は無し
