### PR TITLE
TOPページのアカウント登録ボタンの修正＆テストの追加

### DIFF
--- a/app/views/pages/welcome.html.slim
+++ b/app/views/pages/welcome.html.slim
@@ -40,7 +40,7 @@
     | 初めて利用する方はGitHubアカウントを連携してください。
 
   .flex.justify-center.mb-10.h-12
-    = button_to '/auth/github', method: :post, data: { turbo: false }, class: 'text-gray-800 bg-gray-50 hover:bg-gray-200 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 py-2 mr-2 focus:outline-none' do
+    = button_to '/auth/github', method: :post, data: { turbo: false }, class: 'text-center py-2 px-5 font-semibold text-gray-200 focus:outline-none bg-slate-600 rounded-lg border border-gray-200 hover:bg-slate-500 hover:text-gray-200 focus:z-10 focus:ring-4 focus:ring-gray-100' do
         .flex.items-center
           .mr-2.text-lg
             i.fa-brands.fa-github

--- a/spec/system/login_and_logout_spec.rb
+++ b/spec/system/login_and_logout_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'LoginAndLogout', type: :system do
+  before do
+    FactoryBot.create(:repository, id: 123)
+    OmniAuth.config.mock_auth[:github] =
+      OmniAuth::AuthHash.new({ provider: 'github', uid: 456, info: { nickname: 'kimura', name: '', image: 'https://example.com/avatar.png' } })
+  end
+
+  scenario 'ログインに成功すること' do
+    FactoryBot.create(:user, id: 456, login: 'kimura')
+
+    visit root_path
+    click_button 'ログイン'
+
+    expect(page).to have_current_path '/kimura/issues?association=assigned'
+    expect(page).to have_button 'kimura'
+  end
+
+  context 'ユーザーとして、アカウント登録ボタンをクリックした場合' do
+    scenario 'ログインに成功すること' do
+      FactoryBot.create(:user, id: 456, login: 'kimura')
+
+      visit root_path
+      click_button 'GitHubアカントで登録'
+
+      expect(page).to have_current_path '/kimura/issues?association=assigned'
+      expect(page).to have_button 'kimura'
+    end
+  end
+
+  scenario 'ログアウトに成功すること' do
+    FactoryBot.create(:user, id: 456, login: 'kimura')
+
+    visit root_path
+    click_button 'ログイン'
+
+    click_button 'kimura'
+    click_link 'ログアウト'
+
+    expect(page).to have_current_path '/'
+    expect(page).to have_button 'ログイン'
+  end
+end


### PR DESCRIPTION
## 概要

- #104 で発生したボタンのデザイン崩れとテスト不足を解消