### PR TITLE
ユーザー登録した際に、ユーザーの担当した Issue を取得・登録する機能の作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,4 @@ Rails/SkipsModelValidations:
   Exclude:
     - app/models/issue.rb
     - app/models/labeling.rb
+    - app/models/assign.rb

--- a/app/models/assign.rb
+++ b/app/models/assign.rb
@@ -3,4 +3,13 @@
 class Assign < ApplicationRecord
   belongs_to :assignable, polymorphic: true
   belongs_to :user
+
+  class << self
+    def synchronize(model_name, items_by_github_api, user)
+      user.assigns.where(assignable_type: model_name).where.not(assignable_id: items_by_github_api.map(&:id)).delete_all
+
+      hash_list = items_by_github_api.map { |item| { assignable_type: model_name, assignable_id: item.id, user_id: user.id } }
+      insert_all(hash_list, unique_by: %i[assignable_type assignable_id user_id]) if hash_list.any?
+    end
+  end
 end

--- a/app/models/synchronizer/assigned_issue.rb
+++ b/app/models/synchronizer/assigned_issue.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  class AssignedIssue
+    def call(payload)
+      repository = payload[:repository]
+      user = payload[:user]
+
+      issues = GitHub::Issue.assigned_by(repository, user)
+      Issue.synchronize(issues)
+      Assign.synchronize('Issue', issues, user)
+    end
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,3 +1,4 @@
 Rails.configuration.after_initialize do
   Newspaper.subscribe(:create_user, Synchronizer::CreatedIssue.new)
+  Newspaper.subscribe(:create_user, Synchronizer::AssignedIssue.new)
 end

--- a/db/migrate/20240823200443_create_assigns.rb
+++ b/db/migrate/20240823200443_create_assigns.rb
@@ -6,5 +6,6 @@ class CreateAssigns < ActiveRecord::Migration[7.2]
 
       t.timestamps
     end
+    add_index :assigns, %i[assignable_type assignable_id user_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_26_214346) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["assignable_type", "assignable_id", "user_id"], name: "index_assigns_on_assignable_type_and_assignable_id_and_user_id", unique: true
     t.index ["assignable_type", "assignable_id"], name: "index_assigns_on_assignable"
     t.index ["user_id"], name: "index_assigns_on_user_id"
   end

--- a/spec/models/assign_spec.rb
+++ b/spec/models/assign_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Issue, type: :model do
+  describe '.synchronize' do
+    before do
+      create(:repository, id: 123)
+    end
+
+    context '引数に渡されたデータの中に、既存のアソシエーションに該当しない Issue が存在する場合' do
+      it '対象の Issue とユーザーのアソシエーションを登録する' do
+        user = create(:user, id: 456)
+        create(:issue, :with_author, repository_id: 123, id: 100, number: 10) { |issue| issue.assignees << user }
+        create(:issue, :with_author, repository_id: 123, id: 200, number: 20)
+
+        expect do
+          issues_collected_by_the_github_api = [
+            GitHub::Issue.new(repository_id: 1, issue: { id: 100, user_id: 456, title: 'issue#100', number: 10, labels_id: [] }),
+            GitHub::Issue.new(repository_id: 1, issue: { id: 200, user_id: 456, title: 'issue#200', number: 20, labels_id: [] })
+          ]
+          Assign.synchronize('Issue', issues_collected_by_the_github_api, user)
+        end.to change { user.assigned_issues.ids }.from([100]).to([100, 200])
+      end
+    end
+
+    context '引数に渡されたデータの中に、既存のアソシエーションに該当する Issue が存在しない場合' do
+      it '対象の Issue とユーザーのアソシエーションを削除する' do
+        user = create(:user, id: 456)
+        create(:issue, :with_author, repository_id: 123, id: 100, number: 10) { |issue| issue.assignees << user }
+        create(:issue, :with_author, repository_id: 123, id: 200, number: 20) { |issue| issue.assignees << user }
+
+        expect do
+          issues_collected_by_the_github_api = [
+            GitHub::Issue.new(repository_id: 123, issue: { id: 100, user_id: 456, title: 'issue#100', number: 10, labels_id: [] })
+          ]
+          Assign.synchronize('Issue', issues_collected_by_the_github_api, user)
+        end.to change { user.assigned_issues.ids }.from([100, 200]).to([100])
+      end
+    end
+  end
+end

--- a/spec/models/synchronizer/assigned_issue_spec.rb
+++ b/spec/models/synchronizer/assigned_issue_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Synchronizer::AssignedIssue, type: :model do
+  describe '#call' do
+    before do
+      allow(GitHub::Issue).to receive(:assigned_by)
+      allow(Issue).to receive(:synchronize)
+      allow(Assign).to receive(:synchronize)
+    end
+
+    let(:synchronizer) { Synchronizer::AssignedIssue.new }
+    let(:repository) { create(:repository) }
+    let(:user) { create(:user) }
+
+    it 'GitHubから対象の Issue を取得する(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(GitHub::Issue).to have_received(:assigned_by)
+    end
+
+    it '取得したデータをデータベースへ同期させる(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(Issue).to have_received(:synchronize)
+    end
+
+    it '取得したデータとユーザーのアソシエーション(Assign)を同期させる(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(Assign).to have_received(:synchronize)
+    end
+  end
+end

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -36,15 +36,24 @@ RSpec.describe 'Sign up', type: :system do
   end
 
   context 'ユーザー登録する際', vcr: { cassette_name: 'system/sign_up' } do
-    scenario 'ユーザーが作成した Issue を GitHub から取得＆登録する' do
+    before do
       visit root_path
       click_button 'GitHubアカントで登録'
+    end
 
+    scenario 'ユーザーが作成した Issue を GitHub から取得＆登録する' do
       visit users_issues_path('kimura')
       expect(page).to have_content 'Total 3'
       expect(page).to have_content 'バグの修正'
       expect(page).to have_content '新機能の追加'
       expect(page).to have_content '機能の提案'
+    end
+
+    scenario 'ユーザーが担当した Issue を GitHub から取得＆登録する' do
+      visit users_issues_path('kimura', association: 'assigned')
+      expect(page).to have_content 'Total 2'
+      expect(page).to have_content 'バグの修正'
+      expect(page).to have_content '新機能の追加'
     end
   end
 end

--- a/spec/vcr/system/sign_up.yml
+++ b/spec/vcr/system/sign_up.yml
@@ -77,4 +77,81 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"total_count":3,"items":[{"id":301,"number":301,"title":"バグの修正","user":{"id":"501"},"labels":[{"id":201},{"id":204}],"created_at":"2024-01-13T07:41:50Z","updated_at":"2024-05-20T13:45:40Z"},{"id":302,"number":302,"title":"新機能の追加","user":{"id":"501"},"labels":[{"id":202},{"id":205}],"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T13:45:14Z"},{"id":305,"number":305,"title":"機能の提案","user":{"id":"501"},"labels":[{"id":203}],"created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"}]}'
   recorded_at: Thu, 04 Jul 2024 12:42:42 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:issue%20assignee:kimura
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.1.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Jul 2024 12:42:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-07-11 17:13:17 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      X-Ratelimit-Reset:
+      - '1720097018'
+      X-Ratelimit-Used:
+      - '1'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - github.com
+      X-Github-Request-Id:
+      - E23C:3F406E:8A3AF6:90F590:668698BE
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"items":[{"id":301,"number":301,"title":"バグの修正","labels":[{"id":201},{"id":204}],"user":{"id":"501"},"created_at":"2024-01-13T07:41:50Z","updated_at":"2024-05-20T10:45:40Z"},{"id":302,"number":302,"title":"新機能の追加","labels":[{"id":202},{"id":205}],"user":{"id":"501"},"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T10:45:14Z"}]}'
+  recorded_at: Thu, 04 Jul 2024 12:42:38 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Issue

- #113 

## 概要

- ユーザー登録した際に、ユーザーの担当した Issue を取得・登録する機能の作成
  - ユーザーを登録した (user.save) 際に [Newspaper](https://github.com/komagata/newspaper) を利用して、予め作成した「ユーザーの担当した Issue を取得・登録する」クラスを呼び出す
- アカウント登録時のシステムスペックにテストを追加


## 変更前 / 変更後

動作上の見た目の変化はなし