### PR TITLE
ユーザー登録した際に、ユーザーの担当した PullRequest を取得・登録する機能の作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,5 @@ Rails/SkipsModelValidations:
     - app/models/issue.rb
     - app/models/labeling.rb
     - app/models/assign.rb
+    - app/models/pull_request.rb
+    - app/models/resolution.rb

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -12,6 +12,15 @@ class PullRequest < ApplicationRecord
   has_many :resolutions, dependent: :destroy
   has_many :issues, through: :resolutions, source: :issue
 
+  class << self
+    def synchronize(pull_requests_by_github_api)
+      hash_list = pull_requests_by_github_api.map(&:to_h)
+      upsert_all(hash_list) if hash_list.any?
+
+      Resolution.synchronize(pull_requests_by_github_api)
+    end
+  end
+
   def assignee?(user)
     assignees.include?(user)
   end

--- a/app/models/resolution.rb
+++ b/app/models/resolution.rb
@@ -3,4 +3,17 @@
 class Resolution < ApplicationRecord
   belongs_to :issue
   belongs_to :pull_request
+
+  class << self
+    def synchronize(pull_requests_by_github_api)
+      pull_requests_id = pull_requests_by_github_api.map(&:id)
+      issues_number = pull_requests_by_github_api.flat_map(&:issues_number)
+      issues_id = Issue.where(number: issues_number).ids
+
+      where(pull_request_id: pull_requests_id).where.not(issue_id: issues_id).delete_all
+
+      hash_list = pull_requests_by_github_api.flat_map(&:resolutions)
+      insert_all(hash_list, unique_by: %i[issue_id pull_request_id]) if hash_list.any?
+    end
+  end
 end

--- a/app/models/synchronizer/assigned_pull_request.rb
+++ b/app/models/synchronizer/assigned_pull_request.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  class AssignedPullRequest
+    def call(payload)
+      repository = payload[:repository]
+      user = payload[:user]
+
+      pull_requests = GitHub::PullRequest.assigned_by(repository, user)
+      PullRequest.synchronize(pull_requests)
+      Assign.synchronize('PullRequest', pull_requests, user)
+    end
+  end
+end

--- a/app/views/users/contributions/_list.html.slim
+++ b/app/views/users/contributions/_list.html.slim
@@ -5,7 +5,7 @@
     p.font-medium.text-slate-700
       = content
 
-  ul.ml-2.space-y-2.font-semibold.text-slate-700.list-disc.list-inside
+  ul.ml-2.space-y-2.font-semibold.text-slate-700.list-disc.list-inside(id="#{list_id}")
     - items.each do |item|
       li
         = item.title

--- a/app/views/users/contributions/_table.html.slim
+++ b/app/views/users/contributions/_table.html.slim
@@ -3,7 +3,7 @@
     = table_header
 
   .relative.mt-4.mx-3.overflow-x-auto.shadow-md.sm:rounded-lg
-    table.w-full.text-sm.text-left.rtl:text-right.text-gray-500
+    table.w-full.text-sm.text-left.rtl:text-right.text-gray-500(id="#{table_id}")
       thead.text-gray-50.bg-slate-600.border-b.border-gray-400
         tr
           th.px-6.py-3(col='col')

--- a/app/views/users/contributions/index.html.slim
+++ b/app/views/users/contributions/index.html.slim
@@ -26,11 +26,11 @@ div(data-controller='clipboard')
         .tooltip-arrow.bg-zinc-700(data-popper-arrow)
 
     div(data-clipboard-target='allIssuesTable')
-      = render 'table', table_header: 'Pull Request', issues: @assigned_issues, user: @user
-      = render 'table', table_header: 'Review',       issues: @reviewed_issues, user: @user
+      = render 'table', table_header: 'Pull Request', issues: @assigned_issues, user: @user, table_id: 'assigned_issues'
+      = render 'table', table_header: 'Review',       issues: @reviewed_issues, user: @user, table_id: 'reviewed_issues'
 
       - if @issues.any? || @wikis.any?
         h2.text-2xl.text-slate-600.font-bold.border-b.border-gray-400.pb-2.mb-3
           | その他
-        = render 'list', list_header: 'Issue', content: 'バグ発見の報告や改善提案を目的として作成したIssueです。', items: @issues if @issues.any?
-        = render 'list', list_header: 'Wiki', content: '議事録や作業効率化を目的として作成したWikiページです。', items: @wikis if @wikis.any?
+        = render 'list', list_header: 'Issue', content: 'バグ発見の報告や改善提案を目的として作成したIssueです。', items: @issues, list_id: 'created_issues' if @issues.any?
+        = render 'list', list_header: 'Wiki', content: '議事録や作業効率化を目的として作成したWikiページです。', items: @wikis , list_id: 'created_wikis' if @wikis.any?

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,4 +1,5 @@
 Rails.configuration.after_initialize do
   Newspaper.subscribe(:create_user, Synchronizer::CreatedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::AssignedIssue.new)
+  Newspaper.subscribe(:create_user, Synchronizer::AssignedPullRequest.new)
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -7,4 +7,45 @@ RSpec.describe PullRequest, type: :model do
     pull_request = build(:pull_request, :with_repository)
     expect(pull_request).to be_valid
   end
+
+  describe '.synchronize' do
+    before do
+      create(:repository, id: 123)
+      allow(Resolution).to receive(:synchronize)
+    end
+
+    context '引数の中に「未登録のPullRequest」がある場合' do
+      it '新たに登録すること' do
+        create(:pull_request, repository_id: 123, id: 100, number: 10)
+        pull_requests_collected_by_the_github_api = [
+          GitHub::PullRequest.new(repository_id: 123,
+                                  pull_request: { id: 100, number: 10, issues_number: [],
+                                                  created_at: '2000/01/01 09:00:00', updated_at: '2000/01/01 10:00:00' }),
+          GitHub::PullRequest.new(repository_id: 123,
+                                  pull_request: { id: 200, number: 20, issues_number: [],
+                                                  created_at: '2000/01/01 09:00:00', updated_at: '2000/01/01 10:00:00' })
+        ]
+
+        expect { PullRequest.synchronize(pull_requests_collected_by_the_github_api) }.to change { PullRequest.count }.from(1).to(2)
+      end
+    end
+
+    context '引数の中に「登録済みのPullRequest」がある場合' do
+      it '該当 PullRequest を更新すること' do
+        pull_request = create(:pull_request, repository_id: 123, id: 100, number: 10)
+        pull_requests_collected_by_the_github_api = [
+          GitHub::PullRequest.new(repository_id: 123,
+                                  pull_request: { id: 100, number: 99, issues_number: [],
+                                                  created_at: '2000/01/01 09:00:00', updated_at: '2000/01/01 10:00:00' })
+        ]
+
+        expect { PullRequest.synchronize(pull_requests_collected_by_the_github_api) }.to change { pull_request.reload.number }.from(10).to(99)
+      end
+    end
+
+    it 'PullRequest の description にリンクされた Issue とのアソシエーションを同期させる(メソッドを呼び出す)こと' do
+      PullRequest.synchronize([])
+      expect(Resolution).to have_received(:synchronize)
+    end
+  end
 end

--- a/spec/models/resolution_spec.rb
+++ b/spec/models/resolution_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolution, type: :model do
+  describe '.synchronize' do
+    before do
+      create(:repository, id: 123)
+    end
+
+    context '引数に渡された PullRequest の issues_number 属性に、既存のアソシエーションに登録していない Issue がある場合' do
+      it '対象の Issue とのアソシエーションを登録すること' do
+        pull_request = create(:pull_request, repository_id: 123, id: 300, number: 30)
+        create(:issue, :with_author, repository_id: 123, id: 100, number: 10) { |issue| issue.pull_requests << pull_request }
+        create(:issue, :with_author, repository_id: 123, id: 200, number: 20)
+
+        expect do
+          pull_requests_collected_by_the_github_api = [
+            GitHub::PullRequest.new(repository_id: 123, pull_request: { id: 300, number: 30, issues_number: [10, 20] })
+          ]
+          Resolution.synchronize(pull_requests_collected_by_the_github_api)
+        end.to change { pull_request.issues.ids }.from([100]).to([100, 200])
+      end
+    end
+
+    context '引数に渡された PullRequest の issues_number 属性に、既存のアソシエーションに登録している Issue がない場合' do
+      it '対象の Issue とのアソシエーションを削除すること' do
+        pull_request = create(:pull_request, repository_id: 123, id: 300, number: 30)
+        create(:issue, :with_author, repository_id: 123, id: 100, number: 10) { |issue| issue.pull_requests << pull_request }
+        create(:issue, :with_author, repository_id: 123, id: 200, number: 20) { |issue| issue.pull_requests << pull_request }
+
+        expect do
+          pull_requests_collected_by_the_github_api = [
+            GitHub::PullRequest.new(repository_id: 123, pull_request: { id: 300, number: 30, issues_number: [10] })
+          ]
+          Resolution.synchronize(pull_requests_collected_by_the_github_api)
+        end.to change { pull_request.issues.ids }.from([100, 200]).to([100])
+      end
+    end
+  end
+end

--- a/spec/models/synchronizer/assigned_pull_request_spec.rb
+++ b/spec/models/synchronizer/assigned_pull_request_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Synchronizer::AssignedPullRequest, type: :model do
+  describe '#call' do
+    before do
+      allow(GitHub::PullRequest).to receive(:assigned_by)
+      allow(PullRequest).to receive(:synchronize)
+      allow(Assign).to receive(:synchronize)
+    end
+
+    let(:synchronizer) { Synchronizer::AssignedPullRequest.new }
+    let(:repository) { create(:repository) }
+    let(:user) { create(:user) }
+
+    it 'GitHubから対象の PullRequest を取得する(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(GitHub::PullRequest).to have_received(:assigned_by)
+    end
+
+    it '取得したデータをデータベースへ同期させる(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(PullRequest).to have_received(:synchronize)
+    end
+
+    it '取得したデータとユーザーのアソシエーション(Assign)を同期させる(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(Assign).to have_received(:synchronize)
+    end
+  end
+end

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -44,8 +44,10 @@ RSpec.describe 'Sign up', type: :system do
     within('#assigned_issues') do
       expect(page).to have_content '1'
       expect(page).to have_content 'バグの修正'
+      expect(page).to have_content '#401'
       expect(page).to have_content '2'
       expect(page).to have_content '新機能の追加'
+      expect(page).to have_content '#402'
     end
 
     within('#created_issues') do

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -35,25 +35,23 @@ RSpec.describe 'Sign up', type: :system do
     end
   end
 
-  context 'ユーザー登録する際', vcr: { cassette_name: 'system/sign_up' } do
-    before do
-      visit root_path
-      click_button 'GitHubアカントで登録'
+  scenario 'ユーザー登録する際、作成/担当した Issue を取得すること', vcr: { cassette_name: 'system/sign_up' } do
+    visit root_path
+    click_button 'GitHubアカントで登録'
+
+    visit users_contributions_path('kimura')
+
+    within('#assigned_issues') do
+      expect(page).to have_content '1'
+      expect(page).to have_content 'バグの修正'
+      expect(page).to have_content '2'
+      expect(page).to have_content '新機能の追加'
     end
 
-    scenario 'ユーザーが作成した Issue を GitHub から取得＆登録する' do
-      visit users_issues_path('kimura')
-      expect(page).to have_content 'Total 3'
-      expect(page).to have_content 'バグの修正'
-      expect(page).to have_content '新機能の追加'
-      expect(page).to have_content '機能の提案'
-    end
-
-    scenario 'ユーザーが担当した Issue を GitHub から取得＆登録する' do
-      visit users_issues_path('kimura', association: 'assigned')
-      expect(page).to have_content 'Total 2'
-      expect(page).to have_content 'バグの修正'
-      expect(page).to have_content '新機能の追加'
+    within('#created_issues') do
+      expect(page).to have_content 'バグの報告１'
+      expect(page).to have_content 'バグの報告２'
+      expect(page).to have_content '新機能の提案'
     end
   end
 end

--- a/spec/vcr/system/sign_up.yml
+++ b/spec/vcr/system/sign_up.yml
@@ -75,7 +75,7 @@ http_interactions:
       - E272:3F406E:8A3D34:90F7E8:668698C2
     body:
       encoding: ASCII-8BIT
-      string: '{"total_count":3,"items":[{"id":301,"number":301,"title":"バグの修正","user":{"id":"501"},"labels":[{"id":201},{"id":204}],"created_at":"2024-01-13T07:41:50Z","updated_at":"2024-05-20T13:45:40Z"},{"id":302,"number":302,"title":"新機能の追加","user":{"id":"501"},"labels":[{"id":202},{"id":205}],"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T13:45:14Z"},{"id":305,"number":305,"title":"機能の提案","user":{"id":"501"},"labels":[{"id":203}],"created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"}]}'
+      string: '{"total_count":3,"items":[{"id":303,"number":303,"title":"バグの報告１","user":{"id":"501"},"labels":[{"id":201},{"id":204}],"created_at":"2024-01-13T07:41:50Z","updated_at":"2024-05-20T13:45:40Z"},{"id":304,"number":304,"title":"バグの報告２","user":{"id":"501"},"labels":[{"id":202},{"id":205}],"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T13:45:14Z"},{"id":305,"number":305,"title":"新機能の提案","user":{"id":"501"},"labels":[{"id":203}],"created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"}]}'
   recorded_at: Thu, 04 Jul 2024 12:42:42 GMT
 - request:
     method: get
@@ -154,4 +154,81 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"total_count":2,"items":[{"id":301,"number":301,"title":"バグの修正","labels":[{"id":201},{"id":204}],"user":{"id":"501"},"created_at":"2024-01-13T07:41:50Z","updated_at":"2024-05-20T10:45:40Z"},{"id":302,"number":302,"title":"新機能の追加","labels":[{"id":202},{"id":205}],"user":{"id":"501"},"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T10:45:14Z"}]}'
   recorded_at: Thu, 04 Jul 2024 12:42:38 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:pr%20assignee:kimura%20-label:release
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.1.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Jul 2024 12:42:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-07-11 17:13:17 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '28'
+      X-Ratelimit-Reset:
+      - '1720097018'
+      X-Ratelimit-Used:
+      - '2'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - github.com
+      X-Github-Request-Id:
+      - E24C:37AC3B:1366676:1449B4A:668698BF
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"items":[{"id":401,"number":401,"body":"# Issue\n- #301\n\n# 概要","created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"},{"id":402,"number":402,"body":"# Issue\n- #302\n\n# 概要","created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"}]}'
+  recorded_at: Thu, 04 Jul 2024 12:42:39 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Issue

- #115 

## 概要

- ユーザー登録した際に、ユーザーの担当した PullRequest を取得・登録する機能の作成
  - ユーザーを登録した (user.save) 際に [Newspaper](https://github.com/komagata/newspaper) を利用して、予め作成した「ユーザーの担当した PullRequest を取得・登録する」クラスを呼び出す
- アカウント登録時のシステムスペックにテストを追加


## 変更前 / 変更後

動作上の見た目の変化はなし