### PR TITLE
ユーザー登録した際に、ユーザーのレビューした Issue を取得・登録する機能を作成

### DIFF
--- a/app/models/synchronizer/reviewed_issue.rb
+++ b/app/models/synchronizer/reviewed_issue.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  class ReviewedIssue
+    def call(payload)
+      repository = payload[:repository]
+      user = payload[:user]
+
+      issues = GitHub::Issue.reviewed_by(repository, user)
+      Issue.synchronize(issues)
+    end
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,5 +1,6 @@
 Rails.configuration.after_initialize do
   Newspaper.subscribe(:create_user, Synchronizer::CreatedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::AssignedIssue.new)
+  Newspaper.subscribe(:create_user, Synchronizer::ReviewedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::AssignedPullRequest.new)
 end

--- a/spec/models/synchronizer/reviewed_issue_spec.rb
+++ b/spec/models/synchronizer/reviewed_issue_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Synchronizer::ReviewedIssue, type: :model do
+  describe '#call' do
+    before do
+      allow(GitHub::Issue).to receive(:reviewed_by)
+      allow(Issue).to receive(:synchronize)
+    end
+
+    let(:synchronizer) { Synchronizer::ReviewedIssue.new }
+    let(:repository) { create(:repository) }
+    let(:user) { create(:user) }
+
+    it 'GitHubから対象の Issue を取得する(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(GitHub::Issue).to have_received(:reviewed_by)
+    end
+
+    it '取得したデータをデータベースへ同期させる(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(Issue).to have_received(:synchronize)
+    end
+  end
+end

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Sign up', type: :system do
     end
   end
 
-  scenario 'ユーザー登録する際、作成/担当した Issue を取得すること', vcr: { cassette_name: 'system/sign_up' } do
+  scenario 'ユーザー登録する際、ユーザーの取り組みを取得すること', vcr: { cassette_name: 'system/sign_up' } do
     visit root_path
     click_button 'GitHubアカントで登録'
 
@@ -49,6 +49,14 @@ RSpec.describe 'Sign up', type: :system do
       expect(page).to have_content '新機能の追加'
       expect(page).to have_content '#402'
     end
+
+    # レビューした PullRequest を登録する機能を実装したらコメントアウトを削除する
+    # within('#reviewed_issues') do
+    #   expect(page).to have_content '2'
+    #   expect(page).to have_content 'ロゴの変更'
+    #   expect(page).to have_content '3'
+    #   expect(page).to have_content '既存機能の改修'
+    # end
 
     within('#created_issues') do
       expect(page).to have_content 'バグの報告１'

--- a/spec/vcr/system/sign_up.yml
+++ b/spec/vcr/system/sign_up.yml
@@ -231,4 +231,158 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"total_count":2,"items":[{"id":401,"number":401,"body":"# Issue\n- #301\n\n# 概要","created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"},{"id":402,"number":402,"body":"# Issue\n- #302\n\n# 概要","created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"}]}'
   recorded_at: Thu, 04 Jul 2024 12:42:39 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:pr%20reviewed-by:kimura%20review:approved%20-assignee:kimura
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.1.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Jul 2024 12:42:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-07-11 17:13:17 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '27'
+      X-Ratelimit-Reset:
+      - '1720097018'
+      X-Ratelimit-Used:
+      - '3'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - github.com
+      X-Github-Request-Id:
+      - E250:3772BB:13419D8:1424F0E:668698BF
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"items":[{"id":403,"number":403,"body":"# Issue\n - #306\n\n# 概要","created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"},{"id":404,"number":404,"body":"# Issue\n - #307\n\n# 概要","created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T10:45:14Z"}]}'
+  recorded_at: Thu, 04 Jul 2024 12:42:40 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:issue%20306%20307
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.1.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Jul 2024 12:42:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-07-11 17:13:17 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '26'
+      X-Ratelimit-Reset:
+      - '1720097018'
+      X-Ratelimit-Used:
+      - '4'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - github.com
+      X-Github-Request-Id:
+      - E260:10EE3A:9015C2:96D27B:668698C0
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"items":[{"id":306,"number":306,"title":"ロゴの変更","user":{"id":502},"labels":[{"id":202}],"created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"},{"id":307,"number":307,"title":"既存機能の改修","user":{"id":502},"labels":[{"id":203}],"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T10:45:14Z"}]}'
+  recorded_at: Thu, 04 Jul 2024 12:42:41 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Issue

- #118 

## 概要

- ユーザー登録した際に、ユーザーのレビューした Issue を取得・登録する機能の作成
  - ユーザーを登録した (user.save) 際に [Newspaper](https://github.com/komagata/newspaper) を利用して、予め作成した「ユーザーのレビューした Issue を取得・登録する」クラスを呼び出す
- アカウント登録時のシステムスペックにテストを追加


## 変更前 / 変更後

動作上の見た目の変化はなし