### PR TITLE
ユーザー登録した際に、ユーザーのレビューした PullRequest を取得・登録する機能を作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,4 @@ Rails/SkipsModelValidations:
     - app/models/assign.rb
     - app/models/pull_request.rb
     - app/models/resolution.rb
+    - app/models/review.rb

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -3,4 +3,14 @@
 class Review < ApplicationRecord
   belongs_to :pull_request
   belongs_to :user
+
+  class << self
+    def synchronize(pull_requests_by_github_api, user)
+      pull_requests_id = pull_requests_by_github_api.map(&:id)
+      user.reviews.where.not(pull_request_id: pull_requests_id).delete_all
+
+      hash_list = pull_requests_by_github_api.map { |pull_request| { pull_request_id: pull_request.id, user_id: user.id } }
+      insert_all(hash_list, unique_by: %i[user_id pull_request_id]) if hash_list.any?
+    end
+  end
 end

--- a/app/models/synchronizer/reviewed_pull_request.rb
+++ b/app/models/synchronizer/reviewed_pull_request.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  class ReviewedPullRequest
+    def call(payload)
+      repository = payload[:repository]
+      user = payload[:user]
+
+      pull_requests = GitHub::PullRequest.reviewed_by(repository, user)
+      PullRequest.synchronize(pull_requests)
+      Review.synchronize(pull_requests, user)
+    end
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -3,4 +3,5 @@ Rails.configuration.after_initialize do
   Newspaper.subscribe(:create_user, Synchronizer::AssignedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::ReviewedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::AssignedPullRequest.new)
+  Newspaper.subscribe(:create_user, Synchronizer::ReviewedPullRequest.new)
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Review, type: :model do
+  describe '.synchronize' do
+    before do
+      create(:repository, id: 123)
+    end
+
+    context '引数に渡されたデータの中に、既存のアソシエーションに該当しない PullRequest が存在する場合' do
+      it '対象の PullRequest とユーザーのアソシエーションを登録する' do
+        user = create(:user)
+        create(:pull_request, repository_id: 123, id: 100, number: 10) { |pr| pr.reviewers << user }
+        create(:pull_request, repository_id: 123, id: 200, number: 20)
+
+        prs_collected_by_the_github_api = [
+          GitHub::PullRequest.new(repository_id: 123, pull_request: { id: 100, number: 10, issues_number: [] }),
+          GitHub::PullRequest.new(repository_id: 123, pull_request: { id: 200, number: 20, issues_number: [] })
+        ]
+
+        expect { Review.synchronize(prs_collected_by_the_github_api, user) }.to change { user.reviewed_pull_requests.ids }.from([100]).to([100, 200])
+      end
+    end
+
+    context '引数に渡されたデータの中に、既存のアソシエーションに該当する PullRequest が存在しない場合' do
+      it '対象の PullRequest とユーザーのアソシエーションを削除する' do
+        user = create(:user)
+        create(:pull_request, repository_id: 123, id: 100, number: 10) { |pr| pr.reviewers << user }
+        create(:pull_request, repository_id: 123, id: 200, number: 20) { |pr| pr.reviewers << user }
+
+        prs_collected_by_the_github_api = [
+          GitHub::PullRequest.new(repository_id: 123, pull_request: { id: 100, number: 10, issues_number: [] })
+        ]
+
+        expect { Review.synchronize(prs_collected_by_the_github_api, user) }.to change { user.reviewed_pull_requests.ids }.from([100, 200]).to([100])
+      end
+    end
+  end
+end

--- a/spec/models/synchronizer/reviewed_pull_request_spec.rb
+++ b/spec/models/synchronizer/reviewed_pull_request_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Synchronizer::ReviewedPullRequest, type: :model do
+  describe '#call' do
+    before do
+      allow(GitHub::PullRequest).to receive(:reviewed_by)
+      allow(PullRequest).to receive(:synchronize)
+      allow(Review).to receive(:synchronize)
+    end
+
+    let(:synchronizer) { Synchronizer::ReviewedPullRequest.new }
+    let(:repository) { create(:repository) }
+    let(:user) { create(:user) }
+
+    it 'GitHubから対象の PullRequest を取得する(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(GitHub::PullRequest).to have_received(:reviewed_by)
+    end
+
+    it '取得したデータをデータベースへ同期させる(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(PullRequest).to have_received(:synchronize)
+    end
+
+    it '取得したデータとユーザーのアソシエーション(Review)を同期させる(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(Review).to have_received(:synchronize)
+    end
+  end
+end

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -48,15 +48,16 @@ RSpec.describe 'Sign up', type: :system do
       expect(page).to have_content '2'
       expect(page).to have_content '新機能の追加'
       expect(page).to have_content '#402'
+      expect(page).to have_content '3'
     end
 
-    # レビューした PullRequest を登録する機能を実装したらコメントアウトを削除する
-    # within('#reviewed_issues') do
-    #   expect(page).to have_content '2'
-    #   expect(page).to have_content 'ロゴの変更'
-    #   expect(page).to have_content '3'
-    #   expect(page).to have_content '既存機能の改修'
-    # end
+    within('#reviewed_issues') do
+      expect(page).to have_content '2'
+      expect(page).to have_content 'ロゴの変更'
+      expect(page).to have_content '3'
+      expect(page).to have_content '既存機能の改修'
+      expect(page).to have_content '5'
+    end
 
     within('#created_issues') do
       expect(page).to have_content 'バグの報告１'

--- a/spec/vcr/system/sign_up.yml
+++ b/spec/vcr/system/sign_up.yml
@@ -152,7 +152,7 @@ http_interactions:
       - E23C:3F406E:8A3AF6:90F590:668698BE
     body:
       encoding: ASCII-8BIT
-      string: '{"total_count":2,"items":[{"id":301,"number":301,"title":"バグの修正","labels":[{"id":201},{"id":204}],"user":{"id":"501"},"created_at":"2024-01-13T07:41:50Z","updated_at":"2024-05-20T10:45:40Z"},{"id":302,"number":302,"title":"新機能の追加","labels":[{"id":202},{"id":205}],"user":{"id":"501"},"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T10:45:14Z"}]}'
+      string: '{"total_count":2,"items":[{"id":301,"number":301,"title":"バグの修正","labels":[{"id":201},{"id":204}],"user":{"id":"502"},"created_at":"2024-01-13T07:41:50Z","updated_at":"2024-05-20T10:45:40Z"},{"id":302,"number":302,"title":"新機能の追加","labels":[{"id":202},{"id":205}],"user":{"id":"502"},"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T10:45:14Z"}]}'
   recorded_at: Thu, 04 Jul 2024 12:42:38 GMT
 - request:
     method: get
@@ -385,4 +385,81 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"total_count":2,"items":[{"id":306,"number":306,"title":"ロゴの変更","user":{"id":502},"labels":[{"id":202}],"created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"},{"id":307,"number":307,"title":"既存機能の改修","user":{"id":502},"labels":[{"id":203}],"created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T10:45:14Z"}]}'
   recorded_at: Thu, 04 Jul 2024 12:42:41 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:pr%20reviewed-by:kimura%20review:approved%20-assignee:kimura
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.1.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Jul 2024 12:42:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-07-11 17:13:17 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '27'
+      X-Ratelimit-Reset:
+      - '1720097018'
+      X-Ratelimit-Used:
+      - '3'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - github.com
+      X-Github-Request-Id:
+      - E250:3772BB:13419D8:1424F0E:668698BF
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"items":[{"id":403,"number":403,"body":"# Issue\n - #306\n\n# 概要","created_at":"2024-02-23T11:32:30Z","updated_at":"2024-05-20T10:45:03Z"},{"id":404,"number":404,"body":"# Issue\n - #307\n\n# 概要","created_at":"2024-02-19T10:30:02Z","updated_at":"2024-05-20T10:45:14Z"}]}'
+  recorded_at: Thu, 04 Jul 2024 12:42:40 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Issue

- #117 

## 概要

- ユーザー登録した際に、ユーザーのレビューした PullRequest を取得・登録する機能の作成
  - ユーザーを登録した (user.save) 際に [Newspaper](https://github.com/komagata/newspaper) を利用して、予め作成した「ユーザーのレビューした PullRequest を取得・登録する」クラスを呼び出す
- アカウント登録時のシステムスペックにテストを追加


## 変更前 / 変更後

動作上の見た目の変化はなし