### PR TITLE
アカウント登録時に「リポジトリの情報」 を取得・更新する機能を追加

### DIFF
--- a/app/models/synchronizer/repository.rb
+++ b/app/models/synchronizer/repository.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  class Repository
+    def call(payload)
+      repository = payload[:repository]
+
+      latest_reposiory = GitHub::Repository.find_by(id: repository.id)
+      repository.update!(latest_reposiory.to_h)
+    end
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,4 +1,5 @@
 Rails.configuration.after_initialize do
+  Newspaper.subscribe(:create_user, Synchronizer::Repository.new)
   Newspaper.subscribe(:create_user, Synchronizer::CreatedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::AssignedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::ReviewedIssue.new)

--- a/spec/models/synchronizer/repository_spec.rb
+++ b/spec/models/synchronizer/repository_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Synchronizer::Repository, type: :model do
+  describe '#call' do
+    it 'リポジトリの情報を更新すること' do
+      repo = create(:repository, id: 123, name: 'test/before', avatar_url: 'https://example.com/bofore_avatar.png')
+
+      allow(GitHub::Repository).to receive(:find_by).and_return(
+        GitHub::Repository.new(id: 123, name: 'test/after', avatar_url: 'https://example.com/after_avatar.png',
+                               created_at: '2000/01/01 00:00:00', updated_at: '2000/01/01 00:00:00')
+      )
+
+      synchronizer = Synchronizer::Repository.new
+      expect { synchronizer.call({ repository: repo }) }.to change { repo.reload.name }.from('test/before').to('test/after')
+                                                        .and change { repo.reload.avatar_url }.from('https://example.com/bofore_avatar.png')
+                                                                                              .to('https://example.com/after_avatar.png')
+    end
+  end
+end

--- a/spec/vcr/system/sign_up.yml
+++ b/spec/vcr/system/sign_up.yml
@@ -2,6 +2,83 @@
 http_interactions:
 - request:
     method: get
+    uri: https://api.github.com/repositories/123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.1.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Jul 2024 12:42:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-07-11 17:13:17 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '24'
+      X-Ratelimit-Reset:
+      - '1720097018'
+      X-Ratelimit-Used:
+      - '6'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - github.com
+      X-Github-Request-Id:
+      - E272:3F406E:8A3D34:90F7E8:668698C2
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":123,"full_name":"test/repository","owner":{"avatar_url":"https://example.com/avatar.png"},"created_at":"2000-01-01T00:00:00Z","updated_at":"2000-01-01T00:00:00Z"}'
+  recorded_at: Thu, 04 Jul 2024 12:42:42 GMT
+- request:
+    method: get
     uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:issue%20author:kimura
     body:
       encoding: US-ASCII


### PR DESCRIPTION
## Issue

- #124 

## 概要

- ユーザー登録した際に、リポジトリの情報を取得・登録する機能の作成
  - ユーザーを登録した (user.save) 際に [Newspaper](https://github.com/komagata/newspaper) を利用して、予め作成した「リポジトリの情報を取得・登録する」クラスを呼び出す


## 変更前 / 変更後

動作上の見た目の変化はなし