### PR TITLE
ユーザー登録した際に、ラベルの情報を取得・更新する機能を作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,4 @@ Rails/SkipsModelValidations:
     - app/models/resolution.rb
     - app/models/review.rb
     - app/models/wiki.rb
+    - app/models/label.rb

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -3,4 +3,14 @@
 class Label < ApplicationRecord
   belongs_to :repository
   has_many :labelings, dependent: :destroy
+
+  class << self
+    def synchronize(repository, labels_by_github_api)
+      labels_id = labels_by_github_api.map(&:id)
+      repository.labels.where.not(id: labels_id).delete_all
+
+      hash_list = labels_by_github_api.map(&:to_h)
+      upsert_all(hash_list) if hash_list.any?
+    end
+  end
 end

--- a/app/models/synchronizer/label.rb
+++ b/app/models/synchronizer/label.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  class Label
+    def call(payload)
+      repository = payload[:repository]
+
+      labels = GitHub::Label.registered_by(repository)
+      ::Label.synchronize(repository, labels)
+    end
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,5 +1,6 @@
 Rails.configuration.after_initialize do
   Newspaper.subscribe(:create_user, Synchronizer::Repository.new)
+  Newspaper.subscribe(:create_user, Synchronizer::Label.new)
   Newspaper.subscribe(:create_user, Synchronizer::CreatedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::AssignedIssue.new)
   Newspaper.subscribe(:create_user, Synchronizer::ReviewedIssue.new)

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -7,4 +7,52 @@ RSpec.describe Label, type: :model do
     label = build(:label, :with_repository)
     expect(label).to be_valid
   end
+
+  describe '.synchronize' do
+    let!(:repository) { create(:repository, id: 123) }
+
+    context '引数に渡されたデータの中に「未登録のラベル」がある場合' do
+      it '新たに登録すること' do
+        create(:label, repository_id: 123, id: 100, name: 'bug')
+
+        issues_collected_by_the_github_api = [
+          GitHub::Label.new(repository_id: 123, label: { id: 100, name: 'bug', color: '' }),
+          GitHub::Label.new(repository_id: 123, label: { id: 200, name: 'fix', color: '' })
+        ]
+
+        expect do
+          Label.synchronize(repository, issues_collected_by_the_github_api)
+        end.to change(Label, :count).from(1).to(2)
+      end
+    end
+
+    context '引数に渡されたデータの中に「登録済みのラベル 」がある場合' do
+      it '該当ラベルの情報を更新すること' do
+        label = create(:label, repository_id: 123, id: 100, name: 'bug')
+
+        labels_collected_by_the_github_api = [
+          GitHub::Label.new(repository_id: 123, label: { id: 100, name: 'バグ', color: '' })
+        ]
+
+        expect do
+          Label.synchronize(repository, labels_collected_by_the_github_api)
+        end.to change { label.reload.name }.from('bug').to('バグ')
+      end
+    end
+
+    context '引数に渡されたデータの中に「登録済みのラベル」がない場合' do
+      it '該当ラベルを削除すること' do
+        create(:label, repository_id: 123, id: 100, name: 'bug')
+        create(:label, repository_id: 123, id: 200, name: 'remove')
+
+        labels_collected_by_the_github_api = [
+          GitHub::Label.new(repository_id: 123, label: { id: 100, name: 'bug', color: '' })
+        ]
+
+        expect do
+          Label.synchronize(repository, labels_collected_by_the_github_api)
+        end.to change { Label.pluck(:name) }.from(%w[bug remove]).to(['bug'])
+      end
+    end
+  end
 end

--- a/spec/models/synchronizer/label_spec.rb
+++ b/spec/models/synchronizer/label_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Synchronizer::Label, type: :model do
+  describe '#call' do
+    before do
+      allow(GitHub::Label).to receive(:registered_by)
+      allow(Label).to receive(:synchronize)
+    end
+
+    let(:synchronizer) { Synchronizer::Label.new }
+    let(:repository) { create(:repository) }
+    let(:user) { create(:user) }
+
+    it 'GitHub から Label のデータを取得する(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(GitHub::Label).to have_received(:registered_by)
+    end
+
+    it '取得したデータをデータベースへ同期させる(処理を呼び出す)こと' do
+      synchronizer.call({ repository:, user: })
+      expect(Label).to have_received(:synchronize)
+    end
+  end
+end

--- a/spec/vcr/system/sign_up.yml
+++ b/spec/vcr/system/sign_up.yml
@@ -79,6 +79,83 @@ http_interactions:
   recorded_at: Thu, 04 Jul 2024 12:42:42 GMT
 - request:
     method: get
+    uri: https://api.github.com/repos/test/repository/labels?page=1&per_page=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.1.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Jul 2024 12:42:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Github-Authentication-Token-Expiration:
+      - '2024-07-11 17:13:17 +0900'
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Accepted-Github-Permissions:
+      - allows_permissionless_access=true
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '24'
+      X-Ratelimit-Reset:
+      - '1720097018'
+      X-Ratelimit-Used:
+      - '6'
+      X-Ratelimit-Resource:
+      - search
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - github.com
+      X-Github-Request-Id:
+      - E272:3F406E:8A3D34:90F7E8:668698C2
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":201,"name":"1","color":"2E29EA"},{"id":202,"name":"2","color":"16704F"},{"id":203,"name":"3","color":"7d4c0e"},{"id":204,"name":"bug","color":"d73a4a"},{"id":205,"name":"新機能","color":"EEAE53"}]'
+  recorded_at: Thu, 04 Jul 2024 12:42:42 GMT
+- request:
+    method: get
     uri: https://api.github.com/search/issues?page=1&per_page=100&q=repo:test/repository%20is:issue%20author:kimura
     body:
       encoding: US-ASCII


### PR DESCRIPTION
## Issue

- #125  

## 概要

- ユーザー登録した際に、リポジトリのラベルを取得・登録する機能の作成
  - ユーザーを登録した (user.save) 際に [Newspaper](https://github.com/komagata/newspaper) を利用して、予め作成した「リポジトリのラベルを取得・登録する」クラスを呼び出す
- テストの作成

## 変更前 / 変更後

動作上の見た目の変化はなし