### PR TITLE
ユーザーの取り組み一覧表示のゲスト画面を作成

### DIFF
--- a/app/controllers/users/contributions_controller.rb
+++ b/app/controllers/users/contributions_controller.rb
@@ -2,7 +2,7 @@
 
 class Users::ContributionsController < ApplicationController
   include Settable
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, only: %i[index]
   before_action :set_repository, only: %i[index]
 
   def index
@@ -11,5 +11,11 @@ class Users::ContributionsController < ApplicationController
     @assigned_issues = @user.assigned_issues.order(:created_at)
     @reviewed_issues = @user.reviewed_issues.order(:created_at)
     @wikis = @user.wikis.order(:created_at)
+
+    if @user == current_user
+      render :index
+    else
+      render :unauthorized_index
+    end
   end
 end

--- a/app/views/users/contributions/index.html.slim
+++ b/app/views/users/contributions/index.html.slim
@@ -1,6 +1,5 @@
-- if logged_in?
-  = render 'users/page_header', repository: @repository, user: current_user
-  = render 'users/page_tabs', user: current_user
+= render 'users/page_header', repository: @repository, user: @user
+= render 'users/page_tabs', user: @user
 
 div(data-controller='clipboard')
   .px-10.pt-5.pb-10.flex-grow.max-w-screen-lg.mx-auto

--- a/app/views/users/contributions/unauthorized_index.html.slim
+++ b/app/views/users/contributions/unauthorized_index.html.slim
@@ -1,0 +1,25 @@
+.px-10.pt-5.pb-10.flex-grow.max-w-screen-lg.mx-auto
+  h1.text-2xl.text-slate-600.font-bold.pb-2.my-10.text-center
+    .flex.justify-center.items-center
+      span チーム開発プラクティスでの
+      .mx-2
+        .flex.justify-center.items-center
+          = image_tag @user.avatar_url, class: 'rounded-full w-10 h-10 me-2'
+          .font-bold.text-blue-600
+            - if @user.name?
+                .text-xl.border-b-2.border-blue-600
+                  = @user.name
+                .text-sm.text-left.font-normal
+                  = @user.login
+            - else
+              .text-2xl.border-b-2.border-blue-600
+                = @user.login
+      span さんの取り組み
+  = render 'table', table_header: 'Pull Request', issues: @assigned_issues, user: @user, table_id: 'assigned_issues'
+  = render 'table', table_header: 'Review',       issues: @reviewed_issues, user: @user, table_id: 'reviewed_issues'
+
+  - if @issues.any? || @wikis.any?
+    h2.text-2xl.text-slate-600.font-bold.border-b.border-gray-400.pb-2.mb-3
+      | その他
+    = render 'list', list_header: 'Issue', content: 'バグ発見の報告や改善提案を目的として作成したIssueです。', items: @issues, list_id: 'created_issues' if @issues.any?
+    = render 'list', list_header: 'Wiki', content: '議事録や作業効率化を目的として作成したWikiページです。', items: @wikis , list_id: 'created_wikis' if @wikis.any?

--- a/spec/system/user/user_contributions_spec.rb
+++ b/spec/system/user/user_contributions_spec.rb
@@ -19,20 +19,32 @@ RSpec.describe 'User::Contributions', type: :system do
     create(:wiki, repository_id: 123, title: 'キムラが作成した Wiki', author: kimura)
   end
 
-  let(:kimura) { create(:user, login: 'kimura') }
+  let(:kimura) { create(:user, login: 'kimura', avatar_url: 'https://example.com/avatar_url.png') }
 
   context 'ゲストの場合' do
     scenario 'ユーザーの 作成/担当/レビューした Issue とそれと紐付いた PullRequest 、Wiki を一覧表示する' do
       visit users_contributions_path(kimura.login)
 
-      expect(page).to have_button('Markdown をコピー')
-      expect(page).to have_button('URL をコピー')
-      expect(page).to have_content('キムラが担当した Issue')
-      expect(page).to have_content('#111')
-      expect(page).to have_content('キムラがレビューした Issue')
-      expect(page).to have_content('#222')
-      expect(page).to have_content('キムラが作成した Issue')
-      expect(page).to have_content('キムラが作成した Wiki')
+      expect(page).to have_element(:h1, text: 'kimura')
+      expect(page).to have_element(:img, src: 'https://example.com/avatar_url.png')
+
+      within('#assigned_issues') do
+        expect(page).to have_content('キムラが担当した Issue')
+        expect(page).to have_content('#111')
+      end
+
+      within('#reviewed_issues') do
+        expect(page).to have_content('キムラがレビューした Issue')
+        expect(page).to have_content('#222')
+      end
+
+      within('#created_issues') do
+        expect(page).to have_content('キムラが作成した Issue')
+      end
+
+      within('#created_wikis') do
+        expect(page).to have_content('キムラが作成した Wiki')
+      end
     end
   end
 
@@ -42,12 +54,24 @@ RSpec.describe 'User::Contributions', type: :system do
 
       expect(page).to have_button('Markdown をコピー')
       expect(page).to have_button('URL をコピー')
-      expect(page).to have_content('キムラが担当した Issue')
-      expect(page).to have_content('#111')
-      expect(page).to have_content('キムラがレビューした Issue')
-      expect(page).to have_content('#222')
-      expect(page).to have_content('キムラが作成した Issue')
-      expect(page).to have_content('キムラが作成した Wiki')
+
+      within('#assigned_issues') do
+        expect(page).to have_content('キムラが担当した Issue')
+        expect(page).to have_content('#111')
+      end
+
+      within('#reviewed_issues') do
+        expect(page).to have_content('キムラがレビューした Issue')
+        expect(page).to have_content('#222')
+      end
+
+      within('#created_issues') do
+        expect(page).to have_content('キムラが作成した Issue')
+      end
+
+      within('#created_wikis') do
+        expect(page).to have_content('キムラが作成した Wiki')
+      end
     end
   end
 end

--- a/spec/system/user/user_contributions_spec.rb
+++ b/spec/system/user/user_contributions_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe 'User::Contributions', type: :system do
       expect(page).to have_element(:h1, text: 'kimura')
       expect(page).to have_element(:img, src: 'https://example.com/avatar_url.png')
 
+      expect(page).not_to have_button('Markdown をコピー')
+      expect(page).not_to have_button('URL をコピー')
+
       within('#assigned_issues') do
         expect(page).to have_content('キムラが担当した Issue')
         expect(page).to have_content('#111')


### PR DESCRIPTION
## Issue

#141 

## 概要

- ゲスト用のユーザーの取り組み一覧表示を作成した
- アクセス制御の実装
- テストの改修


## 変更前

<img src="https://github.com/user-attachments/assets/0aefe366-9f56-4a58-86fe-2ac0ac03f4e3" width="700" />


## 変更後

<img src="https://github.com/user-attachments/assets/6eb420bc-3218-43e2-b86f-877a0e6b5ab7" width="700" />
