### PR TITLE
ユーザーがアサインしている Issue の削除機能を作成

### DIFF
--- a/app/models/destroyer/assigned_issue.rb
+++ b/app/models/destroyer/assigned_issue.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Destroyer
+  class AssignedIssue
+    def call(user)
+      user.assigned_issues.not_referenced_by_other_users.destroy_all
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_many :wikis, foreign_key: :author_id, inverse_of: :author, dependent: :destroy
 
   has_many :assigns, dependent: :destroy
-  has_many :assigned_issues, through: :assigns, source: :assignable, source_type: 'Issue'
+  has_many :assigned_issues, through: :assigns, source: :assignable, source_type: 'Issue', extend: IssuesAssociationExtension
   has_many :assigned_pull_requests, through: :assigns, source: :assignable, source_type: 'PullRequest'
 
   has_many :reviews, dependent: :destroy

--- a/spec/models/destroyer/assigned_issue_spec.rb
+++ b/spec/models/destroyer/assigned_issue_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Destroyer::AssignedIssue, type: :model do
+  describe '#call' do
+    let(:repository) { create(:repository, id: 123) }
+    let(:taro) { create(:user, login: 'taro') }
+    let(:jiro) { create(:user, login: 'jiro') }
+    let(:jiro_assigned_pr) { create(:pull_request, repository:) { |pr| pr.assignees << jiro } }
+    let(:jiro_reviewed_pr) { create(:pull_request, repository:) { |pr| pr.reviewers << jiro } }
+
+    it '他のユーザーから参照されていない「ユーザーがアサインしている Issue 」を削除すること' do
+      taro.assigned_issues << [
+        create(:issue, repository:, author_id: 0),
+        create(:issue, repository:, author: jiro),
+        create(:issue, repository:, author_id: 0) { |issue| issue.assignees << jiro },
+        create(:issue, repository:, author_id: 0) { |issue| issue.pull_requests << jiro_assigned_pr },
+        create(:issue, repository:, author_id: 0) { |issue| issue.pull_requests << jiro_reviewed_pr }
+      ]
+
+      destroyer = Destroyer::AssignedIssue.new
+      expect { destroyer.call(taro) }.to change { taro.assigned_issues.count }.from(5).to(4)
+    end
+  end
+end


### PR DESCRIPTION
## Issue

- #132 

## 概要

- `has_many :assigned_issues` に対して、「他のユーザーが参照していない」絞り込み機能を追加
- ユーザーがアサインしている Issue の削除機能を作成
- テストを作成

## 変更前 / 変更後

動作上の見た目の変化はなし