### PR TITLE
ユーザーがレビューした PullRequest の削除機能を作成

### DIFF
--- a/app/models/destroyer/reviewed_pull_request.rb
+++ b/app/models/destroyer/reviewed_pull_request.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Destroyer
+  class ReviewedPullRequest
+    def call(user)
+      user.reviewed_pull_requests.not_referenced_by_other_users.destroy_all
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   has_many :assigned_pull_requests, through: :assigns, source: :assignable, source_type: 'PullRequest', extend: PullRequestsAssociationExtension
 
   has_many :reviews, dependent: :destroy
-  has_many :reviewed_pull_requests, through: :reviews, source: :pull_request
+  has_many :reviewed_pull_requests, through: :reviews, source: :pull_request, extend: PullRequestsAssociationExtension
   has_many :reviewed_issues, through: :reviewed_pull_requests, source: :issues, extend: IssuesAssociationExtension
 
   def self.find_or_initialize_by_github_auth(auth_hash)

--- a/spec/models/destroyer/reviewed_pull_request_spec.rb
+++ b/spec/models/destroyer/reviewed_pull_request_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Destroyer::ReviewedPullRequest, type: :model do
+  describe '#call' do
+    let(:repository) { create(:repository) }
+    let(:taro) { create(:user, login: 'taro') }
+    let(:jiro) { create(:user, login: 'jiro') }
+
+    it '他のユーザーから参照されていない「ユーザーがアサインしている PullRequest 」を削除すること' do
+      taro.reviewed_pull_requests << [
+        create(:pull_request, repository:),
+        create(:pull_request, repository:) { |pr| pr.assignees << jiro },
+        create(:pull_request, repository:) { |pr| pr.reviewers << jiro }
+      ]
+
+      destroyer = Destroyer::ReviewedPullRequest.new
+      expect { destroyer.call(taro) }.to change { taro.reviewed_pull_requests.count }.from(3).to(2)
+    end
+  end
+end


### PR DESCRIPTION
## Issue

- #136 

## 概要

- `has_many :reviewed_pull_requests` に対して、「他のユーザーが参照していない」絞り込み機能を作成
- ユーザーがレビューした PullRequest の削除機能を作成
- テストを作成

## 変更前 / 変更後

動作上の見た目の変化はなし