### PR TITLE
退会機能を作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,4 +12,11 @@ class UsersController < ApplicationController
 
     redirect_to request.headers[:HTTP_REFERER]
   end
+
+  def destroy
+    Newspaper.publish(:user_destroy, current_user)
+    current_user.destroy!
+    reset_session
+    redirect_to root_path, notice: 'アカウントを削除しました', status: :see_other
+  end
 end

--- a/app/javascript/controllers/accept_confirm_controller.js
+++ b/app/javascript/controllers/accept_confirm_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  static targets = ['modal', 'dialog', 'loading']
+
+  showLoading() {
+    this.dialogTarget.classList.add('hidden')
+    this.loadingTarget.classList.remove('hidden')
+    this.modalTarget.classList.add('pointer-events-none')
+  }
+}

--- a/app/views/shared/_flash.html.slim
+++ b/app/views/shared/_flash.html.slim
@@ -1,11 +1,11 @@
 - flash.each do |flash_type, message|
   div(id="toast-#{flash_type}" data-controller="toast")
-    .hidden.fixed.flex.items-center.w-full.max-w-xs.p-4.mb-4.top-5.right-5.rounded-lg.shadow.text-white(data-toast-target="toast" class="#{flash_bg_classes_for(flash_type)}" role="alert")
+    .hidden.fixed.flex.items-center.w-fit.mix-w-xs.p-4.mb-4.top-5.right-5.rounded-lg.shadow.text-white(data-toast-target="toast" class="#{flash_bg_classes_for(flash_type)}" role="alert")
       .inline-flex.items-center.justify-center.flex-shrink-0.w-8.h-8.bg-white.rounded-lg(class="#{flash_icon_classes_for(flash_type)}")
         - case flash_type.to_s
         - when 'notice'
           svg(class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20")
-              path(d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z")
+            path(d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z")
           span.sr-only
             | Check icon
         - when 'alert'
@@ -13,10 +13,10 @@
             path(d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 11.793a1 1 0 1 1-1.414 1.414L10 11.414l-2.293 2.293a1 1 0 0 1-1.414-1.414L8.586 10 6.293 7.707a1 1 0 0 1 1.414-1.414L10 8.586l2.293-2.293a1 1 0 0 1 1.414 1.414L11.414 10l2.293 2.293Z")
           span.sr-only
             | Error icon
-      .ms-3.text-base.font-semibold
+      .ms-3.me-3.text-base.font-semibold
         = message
-      button(type="button" class="ms-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8 dark:text-gray-500 dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700" data-dismiss-target="#toast-#{flash_type}" aria-label="Close")
+      button(id="toast-close" type="button" class="ms-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8 dark:text-gray-500 dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700" data-dismiss-target="#toast-#{flash_type}" aria-label="Close")
         span.sr-only
           | Close
-        svg(class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14")
+        svg(lass="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14")
           path(stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6")

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -25,7 +25,7 @@ header
           #dropdownAvatarName.z-10.hidden.bg-gray-500.text-gray-50.font-semibold.divide-y.divide-gray-100.rounded-lg.shadow.w-52
             .py-2
               .text-sm.hover:bg-red-500
-                = link_to user_path(current_user), data: { turbo_method: :delete, turbo_confirm: '本当に実行しますか？' } do
+                = button_tag data: { modal_target: 'retirement-modal', modal_toggle: 'retirement-modal' } do
                   .w-full.px-4.py-2
                     i.fa-solid.fa-trash-can.pr-2
                     | アカウント削除
@@ -35,6 +35,7 @@ header
                   .w-full.px-4.py-2
                     i.fa-solid.fa-arrow-right-from-bracket.pr-2
                     | ログアウト
+          = render 'shared/modal', path: user_path(current_user), method: :delete, message: '本当に実行しますか？', modal_id: 'retirement-modal'
         - else
           = button_to 'ログイン', '/auth/github', method: :post,
                       data: { turbo: false },

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -24,6 +24,12 @@ header
                     path(stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m1 1 4 4 4-4')
           #dropdownAvatarName.z-10.hidden.bg-gray-500.text-gray-50.font-semibold.divide-y.divide-gray-100.rounded-lg.shadow.w-52
             .py-2
+              .text-sm.hover:bg-red-500
+                = link_to user_path(current_user), data: { turbo_method: :delete, turbo_confirm: '本当に実行しますか？' } do
+                  .w-full.px-4.py-2
+                    i.fa-solid.fa-trash-can.pr-2
+                    | アカウント削除
+            .py-2
               .text-sm.hover:bg-gray-400
                 = link_to logout_path, data: { turbo_method: :delete } do
                   .w-full.px-4.py-2

--- a/app/views/shared/_modal.html.slim
+++ b/app/views/shared/_modal.html.slim
@@ -1,0 +1,32 @@
+div(data-controller="accept-confirm")
+  .hidden.overflow-y-auto.overflow-x-hidden.fixed.top-0.right-0.left-0.z-50.justify-center.items-center.w-full.max-h-full(id="#{modal_id}" data-accept-confirm-target="modal" tabindex="-1" class="md:inset-0 h-[calc(100%-1rem)]")
+    .relative.p-4.w-full.max-w-md.max-h-full.min-h-64.text-xl.text-gray-600.font-medium
+      .relative.flex.justify-center.items-center.min-w-80.min-h-64.p-4.bg-white.rounded-lg.shadow
+        .flex.justify-center.items-center(data-accept-confirm-target="dialog")
+          button.absolute.top-3.text-gray-400.bg-transparent.hover:bg-gray-200.hover:text-gray-900.rounded-lg.text-sm.w-8.h-8.ms-auto.inline-flex.justify-center.items-center(type="button" class="end-2.5" data-modal-hide="#{modal_id}")
+            svg(class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14")
+              path(stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6")
+            span(class="sr-only")
+              | Close modal
+          .p-4.md:p-5.text-center
+            svg(class="mx-auto mb-6 text-gray-400 w-16 h-16 dark:text-gray-200" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20")
+                path(stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 11V6m0 8h.01M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z")
+            p.mb-5.text-xl.font-medium.text-gray-500
+              = message
+            .flex.justify-center
+              = link_to path, data: { turbo_method: method, action: 'click->accept-confirm#showLoading' }, class: "text-white bg-red-600 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 dark:focus:ring-red-800 font-medium rounded-lg text-sm inline-flex items-center px-5 py-2.5 text-center" do
+                | OK
+              button(data-modal-hide="#{modal_id}" type="button" class="py-2.5 px-5 ms-3 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700")
+                | Cancel
+        .hidden.flex.justify-center.items-center(data-accept-confirm-target="loading")
+          .flex-row.text-center
+            .text-center.mb-6
+              div(role="status")
+                svg(aria-hidden="true" class="inline w-16 h-16 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg")
+                    path(d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor")
+                    path(d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill")
+                span(class="sr-only")
+                  | Loading...
+            .text-xl.font-medium.text-gray-500
+              p.p-4 処理を実行しています
+              p しばらくお待ちください...

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -17,9 +17,9 @@ Rails.configuration.after_initialize do
   Newspaper.subscribe(:update_user, Synchronizer::ReviewedPullRequest.new)
   Newspaper.subscribe(:update_user, Synchronizer::CreatedWiki.new)
 
-  Newspaper.subscribe(:update_user, Destroyer::CreatedIssue.new)
-  Newspaper.subscribe(:update_user, Destroyer::AssignedIssue.new)
-  Newspaper.subscribe(:update_user, Destroyer::ReviewedIssue.new)
-  Newspaper.subscribe(:update_user, Destroyer::AssignedPullRequest.new)
-  Newspaper.subscribe(:update_user, Destroyer::ReviewedPullRequest.new)
+  Newspaper.subscribe(:user_destroy, Destroyer::CreatedIssue.new)
+  Newspaper.subscribe(:user_destroy, Destroyer::AssignedIssue.new)
+  Newspaper.subscribe(:user_destroy, Destroyer::ReviewedIssue.new)
+  Newspaper.subscribe(:user_destroy, Destroyer::AssignedPullRequest.new)
+  Newspaper.subscribe(:user_destroy, Destroyer::ReviewedPullRequest.new)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -16,4 +16,10 @@ Rails.configuration.after_initialize do
   Newspaper.subscribe(:update_user, Synchronizer::AssignedPullRequest.new)
   Newspaper.subscribe(:update_user, Synchronizer::ReviewedPullRequest.new)
   Newspaper.subscribe(:update_user, Synchronizer::CreatedWiki.new)
+
+  Newspaper.subscribe(:update_user, Destroyer::CreatedIssue.new)
+  Newspaper.subscribe(:update_user, Destroyer::AssignedIssue.new)
+  Newspaper.subscribe(:update_user, Destroyer::ReviewedIssue.new)
+  Newspaper.subscribe(:update_user, Destroyer::AssignedPullRequest.new)
+  Newspaper.subscribe(:update_user, Destroyer::ReviewedPullRequest.new)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
     resources :wikis, only: %i[index]
     resources :contributions, only: %i[index]
   end
-  resources :users, only: %i[update]
+  resources :users, only: %i[update destroy]
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -48,11 +48,13 @@ RSpec.describe 'Users', type: :system do
     click_button 'toast-close'
 
     expect do
-      accept_confirm do
-        click_button 'kimura'
-        click_link 'アカウント削除'
-      end
+      click_button 'kimura'
+      click_button 'アカウント削除'
+      click_link 'OK'
+
       expect(page).to have_content 'アカウントを削除しました'
     end.to change(User, :count).by(-1)
+
+    expect(Newspaper).to have_received(:publish).with(:user_destroy, kind_of(User))
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Users', type: :system do
   before do
     allow(Newspaper).to receive(:publish).with(:update_user, kind_of(Hash))
+    allow(Newspaper).to receive(:publish).with(:user_destroy, kind_of(User))
   end
 
   scenario 'ユーザー情報を更新する', vcr: { cassette_name: 'system/user_update' } do
@@ -37,5 +38,21 @@ RSpec.describe 'Users', type: :system do
       expect(page).to have_content '更新に失敗しました'
       expect(page).to have_current_path users_wikis_path(kimura.login)
     end
+  end
+
+  scenario 'ユーザーを削除する' do
+    create(:repository, id: 123, name: 'test/repository')
+    kimura = create(:user, login: 'kimura')
+
+    login_as kimura
+    click_button 'toast-close'
+
+    expect do
+      accept_confirm do
+        click_button 'kimura'
+        click_link 'アカウント削除'
+      end
+      expect(page).to have_content 'アカウントを削除しました'
+    end.to change(User, :count).by(-1)
   end
 end


### PR DESCRIPTION
## Issue

- #130 

## 概要

- 退会処理を作成
- 確認モーダルを Flobite 化 ＆ Stimulus により動作をカスタマイズ ( OK をクリック後、モーダルを消さず処理中であることを表示する )
- テストを作成

## 変更前 

なし

## 変更後

<img src="https://github.com/user-attachments/assets/022c1eb4-0788-4a45-a394-9db39f2ceacf" width="700" />