### PR TITLE
一覧表示する Issue, PullRequest, Wiki を GitHub のオリジナルデータへのジャンプできるようにリンクへ変更にした

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,2 @@
 REPOSITORY_NAME = 'test/repository'
+GITHUB_URL = 'https://example.com'

--- a/app/decorators/issue_decorator.rb
+++ b/app/decorators/issue_decorator.rb
@@ -4,4 +4,9 @@ module IssueDecorator
   def point
     labels.pluck(:name).sum(&:to_i)
   end
+
+  def url
+    base_url = ENV['GITHUB_URL']
+    "#{base_url}/#{repository.name}/issues/#{number}"
+  end
 end

--- a/app/decorators/pull_request_decorator.rb
+++ b/app/decorators/pull_request_decorator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module PullRequestDecorator
+  def url
+    base_url = ENV['GITHUB_URL']
+    "#{base_url}/#{repository.name}/pull/#{number}"
+  end
+end

--- a/app/decorators/wiki_decorator.rb
+++ b/app/decorators/wiki_decorator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module WikiDecorator
+  def url
+    base_url = ENV['GITHUB_URL']
+    "#{base_url}/#{repository.name}/wiki/#{title}"
+  end
+end

--- a/app/views/users/_page_body.html.slim
+++ b/app/views/users/_page_body.html.slim
@@ -8,7 +8,7 @@
           - items.each do |item|
             .bg-white.border-b.hover:bg-gray-100.px-6.py-2.font-bold.text-slate-700
               .w-fit.text-base.hover:text-blue-600
-                = item.title
+                = link_to item.title, item.url, { target: '_blank', rel: 'noopener noreferrer' }
               - if item.instance_of?(Issue)
                 .flex.items-center.pt-1.space-x-2
                   .px-2.text-xs.font-medium.text-slate-500.

--- a/app/views/users/contributions/_list.html.slim
+++ b/app/views/users/contributions/_list.html.slim
@@ -8,4 +8,4 @@
   ul.ml-2.space-y-2.font-semibold.text-slate-700.list-disc.list-inside(id="#{list_id}")
     - items.each do |item|
       li
-        = item.title
+        = link_to item.title, item.url, { target: '_blank', rel: 'noopener noreferrer' }

--- a/app/views/users/contributions/_table.html.slim
+++ b/app/views/users/contributions/_table.html.slim
@@ -3,28 +3,31 @@
     = table_header
 
   .relative.mt-4.mx-3.overflow-x-auto.shadow-md.sm:rounded-lg
-    table.w-full.text-sm.text-left.rtl:text-right.text-gray-500(id="#{table_id}")
+    table.table-fixed.w-full.text-sm.text-left.rtl:text-right.text-gray-500(id="#{table_id}")
       thead.text-gray-50.bg-slate-600.border-b.border-gray-400
         tr
-          th.px-6.py-3(col='col')
+          th.px-6.py-3(class="w-1/12")
             | Point
-          th.px-6.py-3(col='col')
+          th.px-6.py-3(class="w-4/5")
             | Issue
-          th.px-6.py-3(col='col')
+          th.px-6.py-3(class="w-auto")
             | PR
       tbody
         - if issues.any?
           - issues.each do |issue|
             tr.font-semibold.odd:bg-gray-200.text-slate-800.even:bg-gray-100.border-b.border-gray-400
-              td.px-6.py-3
+              td.px-6.py-3.text-center
                 = issue.point || '-'
               td.px-6.py-3
-                = issue.title
-              td.px-6.py-3
-                - issue.pull_requests.each do |pull_request|
-                  - if (table_header == 'Pull Request' && pull_request.assignee?(user)) || (table_header == 'Review' && pull_request.reviewer?(user))
-                    = "##{pull_request.number}"
-                    br
+                = link_to issue.title, issue.url, { target: '_blank', rel: 'noopener noreferrer' }
+              td.px-6.py-3.text-center
+                - if issue.pull_requests.empty?
+                  | -
+                - else
+                  - issue.pull_requests.each do |pull_request|
+                    - if (table_header == 'Pull Request' && pull_request.assignee?(user)) || (table_header == 'Review' && pull_request.reviewer?(user))
+                      = link_to "##{pull_request.number}", pull_request.url, { target: '_blank', rel: 'noopener noreferrer' }
+                br
         - else
             tr.font-semibold.bg-gray-200.text-slate-800.border-b.border-gray-400
               td.px-6.py-3
@@ -35,7 +38,7 @@
                 | -
       tfoot
         tr.bg-slate-600.font-semibold.text-gray-50
-          th.px-6.py-3
+          th.px-6.py-3.text-center
             = issues.sum(&:point)
           td.px-6.py-3
             | Total

--- a/spec/decorators/issue_decorator_spec.rb
+++ b/spec/decorators/issue_decorator_spec.rb
@@ -36,4 +36,14 @@ RSpec.describe IssueDecorator do
       end
     end
   end
+
+  describe '#url' do
+    it '「環境変数(dotenv)に設定したGitHubのURL + リポジトリ名 + issues + Issueのナンバー」に変換した URL を返すこと' do
+      create(:repository, id: 123, name: 'test/repository')
+      issue = create(:issue, :with_author, repository_id: 123, number: 456)
+      decorator_issue = ActiveDecorator::Decorator.instance.decorate(issue)
+
+      expect(decorator_issue.url).to eq 'https://example.com/test/repository/issues/456'
+    end
+  end
 end

--- a/spec/decorators/pull_request_decorator_spec.rb
+++ b/spec/decorators/pull_request_decorator_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PullRequestDecorator do
+  describe '#url' do
+    it '「環境変数(dotenv)に設定したGitHubのURL + リポジトリ名 + pull + PullRequestのナンバー」に変換した URL を返すこと' do
+      create(:repository, id: 123, name: 'test/repository')
+      pull_request = create(:pull_request, repository_id: 123, number: 456)
+      decorator_pull_request = ActiveDecorator::Decorator.instance.decorate(pull_request)
+
+      expect(decorator_pull_request.url).to eq 'https://example.com/test/repository/pull/456'
+    end
+  end
+end

--- a/spec/decorators/wiki_decorator_rspec.rb
+++ b/spec/decorators/wiki_decorator_rspec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WikiDecorator do
+  describe '#url' do
+    it '「環境変数(dotenv)に設定したGitHubのURL + リポジトリ名 + wiki + Wikiのタイトル」に変換した URL を返すこと' do
+      create(:repository, id: 123, name: 'test/repository')
+      wiki = create(:wiki, :with_author, repository_id: 123, title: '議事録#001')
+      decorator_wiki = ActiveDecorator::Decorator.instance.decorate(wiki)
+
+      expect(decorator_wiki.url).to eq 'https://example.com/test/repository/wiki/議事録#001'
+    end
+  end
+end

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -48,31 +48,31 @@ RSpec.describe 'Sign up', type: :system do
 
       within('#assigned_issues') do
         expect(page).to have_content '1'
-        expect(page).to have_content 'バグの修正'
-        expect(page).to have_content '#401'
+        expect(page).to have_link 'バグの修正'
+        expect(page).to have_link '#401'
         expect(page).to have_content '2'
-        expect(page).to have_content '新機能の追加'
-        expect(page).to have_content '#402'
+        expect(page).to have_link '新機能の追加'
+        expect(page).to have_link '#402'
         expect(page).to have_content '3'
       end
 
       within('#reviewed_issues') do
         expect(page).to have_content '2'
-        expect(page).to have_content 'ロゴの変更'
+        expect(page).to have_link 'ロゴの変更'
         expect(page).to have_content '3'
-        expect(page).to have_content '既存機能の改修'
+        expect(page).to have_link '既存機能の改修'
         expect(page).to have_content '5'
       end
 
       within('#created_issues') do
-        expect(page).to have_content 'バグの報告１'
-        expect(page).to have_content 'バグの報告２'
-        expect(page).to have_content '新機能の提案'
+        expect(page).to have_link 'バグの報告１'
+        expect(page).to have_link 'バグの報告２'
+        expect(page).to have_link '新機能の提案'
       end
 
       within('#created_wikis') do
-        expect(page).to have_content '議事録１'
-        expect(page).to have_content '議事録２'
+        expect(page).to have_link '議事録１'
+        expect(page).to have_link '議事録２'
       end
     end
   end

--- a/spec/system/user/user_contributions_spec.rb
+++ b/spec/system/user/user_contributions_spec.rb
@@ -5,16 +5,13 @@ require 'rails_helper'
 RSpec.describe 'User::Contributions', type: :system do
   before do
     create(:repository, id: 123, name: 'test/repository')
-
     create(:issue, :with_author, repository_id: 123, title: 'キムラが担当した Issue') do |issue|
       issue.assignees << kimura
       issue.pull_requests << create(:pull_request, repository_id: 123, number: 111) { |pr| pr.assignees << kimura }
     end
-
     create(:issue, :with_author, repository_id: 123, title: 'キムラがレビューした Issue') do |issue|
       issue.pull_requests << create(:pull_request, repository_id: 123, number: 222) { |pr| pr.reviewers << kimura }
     end
-
     create(:issue, repository_id: 123, title: 'キムラが作成した Issue', author: kimura)
     create(:wiki, repository_id: 123, title: 'キムラが作成した Wiki', author: kimura)
   end
@@ -32,21 +29,21 @@ RSpec.describe 'User::Contributions', type: :system do
       expect(page).not_to have_button('URL をコピー')
 
       within('#assigned_issues') do
-        expect(page).to have_content('キムラが担当した Issue')
-        expect(page).to have_content('#111')
+        expect(page).to have_link('キムラが担当した Issue')
+        expect(page).to have_link('#111')
       end
 
       within('#reviewed_issues') do
-        expect(page).to have_content('キムラがレビューした Issue')
-        expect(page).to have_content('#222')
+        expect(page).to have_link('キムラがレビューした Issue')
+        expect(page).to have_link('#222')
       end
 
       within('#created_issues') do
-        expect(page).to have_content('キムラが作成した Issue')
+        expect(page).to have_link('キムラが作成した Issue')
       end
 
       within('#created_wikis') do
-        expect(page).to have_content('キムラが作成した Wiki')
+        expect(page).to have_link('キムラが作成した Wiki')
       end
     end
   end
@@ -59,21 +56,21 @@ RSpec.describe 'User::Contributions', type: :system do
       expect(page).to have_button('URL をコピー')
 
       within('#assigned_issues') do
-        expect(page).to have_content('キムラが担当した Issue')
-        expect(page).to have_content('#111')
+        expect(page).to have_link('キムラが担当した Issue')
+        expect(page).to have_link('#111')
       end
 
       within('#reviewed_issues') do
-        expect(page).to have_content('キムラがレビューした Issue')
-        expect(page).to have_content('#222')
+        expect(page).to have_link('キムラがレビューした Issue')
+        expect(page).to have_link('#222')
       end
 
       within('#created_issues') do
-        expect(page).to have_content('キムラが作成した Issue')
+        expect(page).to have_link('キムラが作成した Issue')
       end
 
       within('#created_wikis') do
-        expect(page).to have_content('キムラが作成した Wiki')
+        expect(page).to have_link('キムラが作成した Wiki')
       end
     end
   end

--- a/spec/system/user/user_issues_spec.rb
+++ b/spec/system/user/user_issues_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe 'User::Issues', type: :system do
       login_as kimura, to: users_issues_path('kimura')
 
       expect(page).to have_content 'Total 2'
-      expect(page).to have_content 'Issue A'
-      expect(page).to have_content 'Issue B'
+      expect(page).to have_link 'Issue A'
+      expect(page).to have_link 'Issue B'
     end
 
     scenario '本人が担当した Issue を一覧表示する' do
@@ -35,25 +35,22 @@ RSpec.describe 'User::Issues', type: :system do
       login_as kimura, to: users_issues_path('kimura', association: 'assigned')
 
       expect(page).to have_content 'Total 2'
-      expect(page).to have_content 'Issue C'
-      expect(page).to have_content 'Issue D'
+      expect(page).to have_link 'Issue C'
+      expect(page).to have_link 'Issue D'
     end
 
     scenario '本人がレビューした Issue を一覧表示する' do
       create(:repository, id: 123, name: 'test/repository')
       kimura = create(:user, login: 'kimura')
-      create(:issue, :with_author, repository_id: 123, title: 'Issue E') do |issue|
-        issue.pull_requests << create(:pull_request, repository_id: 123) { |pr| pr.reviewers << kimura }
-      end
-      create(:issue, :with_author, repository_id: 123, title: 'Issue F') do |issue|
-        issue.pull_requests << create(:pull_request, repository_id: 123) { |pr| pr.reviewers << kimura }
-      end
+      kimura_reviewed_pr = create(:pull_request, repository_id: 123) { |pr| pr.reviewers << kimura }
+      create(:issue, :with_author, repository_id: 123, title: 'Issue E') { |issue| issue.pull_requests << kimura_reviewed_pr }
+      create(:issue, :with_author, repository_id: 123, title: 'Issue F') { |issue| issue.pull_requests << kimura_reviewed_pr }
 
       login_as kimura, to: users_issues_path('kimura', association: 'reviewed')
 
       expect(page).to have_content 'Total 2'
-      expect(page).to have_content 'Issue E'
-      expect(page).to have_content 'Issue F'
+      expect(page).to have_link 'Issue E'
+      expect(page).to have_link 'Issue F'
     end
   end
 end

--- a/spec/system/user/user_wikis_spec.rb
+++ b/spec/system/user/user_wikis_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe 'User::Wikis', type: :system do
 
       login_as kimura, to: users_wikis_path(kimura.login)
 
-      expect(page).to have_content '議事録01'
-      expect(page).to have_content '議事録02'
-      expect(page).to have_content '議事録03'
+      expect(page).to have_link '議事録01'
+      expect(page).to have_link '議事録02'
+      expect(page).to have_link '議事録03'
     end
   end
 end


### PR DESCRIPTION
## Issue

- #158 


## 概要

- 一覧表示する Issue, PullRequest, Wiki を GitHub のオリジナルデータへジャンプできるようにリンクにした
- URL を作成するヘルパー ( decorator ) を作成
- テストの作成＆修正


## 変更前 / 変更後

見た目にはあまり変化がないので省略