### PR TITLE
デザインレビュー向けに GitHub 認証のモックを設定した

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -5,3 +5,19 @@ end
 OmniAuth.config.on_failure = Proc.new { |env|
   OmniAuth::FailureEndpoint.new(env).redirect_to_failure
 }
+
+# デザインレビュー用の設定
+# レビューが終わり次第削除する
+if Rails.env.production?
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+    provider: 'github',
+    uid: 95903475,
+    info: {
+      nickname: 'ymmtd0x0b',
+      name: 'ヤマモト',
+      image: 'https://avatars.githubusercontent.com/u/95903475?v=4'
+    }
+  )
+end
+# ここまで


### PR DESCRIPTION
## 概要

自作サービスには GitHub 認証しかない都合上、状況再現が難しいのでデザインレビュー向けに GitHub 認証をモックして常に特定ユーザーでログインできるようにした。

この変更はデザインレビュー後に削除する